### PR TITLE
feat: automate source firmware releases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@
 
 ### Package type
 
-- [ ] Complete source and firmware
+- [ ] Source contribution built by GitHub Actions
 - [ ] Firmware-only package
 
 ## What this contribution provides
@@ -32,26 +32,27 @@ List the commands and manual checks completed for this contribution.
 - [ ] The author, source, support, and documentation links are current.
 - [ ] The logo and preview image are included, or the existing approved assets are reused unchanged.
 - [ ] The submitted files contain no user-specific credentials, API keys, tokens, passwords, or private keys.
-- [ ] The local manifest records every firmware file, flash offset, byte size, and SHA-256.
+- [ ] The selected package type has all required source or firmware files.
 
-## Complete-source verification
+## Source contribution verification
 
-Complete this section when **Complete source and firmware** is selected.
+Complete this section when **Source contribution built by GitHub Actions** is selected.
 
 - [ ] Not applicable because **Firmware-only package** is selected.
 - [ ] `source.path` and `build` are both present and identify the tested source tree, build system, version, and target.
 - [ ] The local source includes its license and every dependency needed for a clean build.
-- [ ] Supported ESP-IDF projects enable `CONFIG_APP_REPRODUCIBLE_BUILD=y`.
-- [ ] A clean build reproduces the submitted firmware package.
+- [ ] The newest firmware version sets `sourceBuild: true`.
+- [ ] The GitHub Actions source build passes and provides the firmware artifact.
 
 ## Firmware-only verification
 
 Complete this section when **Firmware-only package** is selected.
 
-- [ ] Not applicable because **Complete source and firmware** is selected.
+- [ ] Not applicable because **Source contribution built by GitHub Actions** is selected.
 - [ ] `source.url` points to the upstream source and `source.license` identifies its license.
 - [ ] The README identifies the exact package origin, firmware version, and tested hardware.
 - [ ] Every required `.bin` file is committed under `firmware/<version>/`.
+- [ ] The local manifest records every firmware file, flash offset, byte size, and SHA-256.
 
 ## New community integration verification
 
@@ -80,7 +81,7 @@ Complete this section when **Existing integration update** is selected.
 - Reboot and saved-state result:
 - USB reconnection and repeated-install result:
 
-- [ ] The submitted package was installed on a physical reTerminal Sticky.
+- [ ] The submitted firmware-only package or a local build of the submitted source was installed on a physical reTerminal Sticky.
 - [ ] First boot and the main user workflow passed.
 - [ ] Touch and hardware buttons used by the firmware passed.
 - [ ] Reboot, saved state, USB reconnection, and repeated installation were tested where applicable.

--- a/.github/workflows/validate-registry.yml
+++ b/.github/workflows/validate-registry.yml
@@ -89,7 +89,56 @@ jobs:
           esp_idf_version: ${{ matrix.idfVersion }}
           target: ${{ matrix.target }}
           path: ${{ matrix.path }}
-          command: idf.py build
+          command: idf.py -D PROJECT_VER=${{ matrix.version }} build
 
-      - name: Verify packaged firmware
-        run: node scripts/verify-esp-idf-build.mjs "${{ matrix.id }}"
+      - name: Package firmware
+        env:
+          FIRMWARE_OUTPUT_DIR: firmware-output/${{ matrix.id }}/${{ matrix.versionSlug }}
+          REGISTRY_COMMIT: ${{ github.sha }}
+        run: npm run package:esp-idf -- "${{ matrix.id }}" "${{ matrix.version }}"
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-${{ matrix.id }}-${{ matrix.versionSlug }}
+          path: firmware-output/${{ matrix.id }}/${{ matrix.versionSlug }}
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-firmware:
+    name: Publish ${{ matrix.id }} ${{ matrix.version }}
+    needs:
+      - discover-firmware
+      - build-firmware
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.discover-firmware.outputs.matrix != '{"include":[]}' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover-firmware.outputs.matrix) }}
+
+    steps:
+      - name: Download firmware artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware-${{ matrix.id }}-${{ matrix.versionSlug }}
+          path: firmware-output/${{ matrix.id }}/${{ matrix.versionSlug }}
+
+      - name: Publish firmware release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: registry-${{ matrix.id }}-${{ matrix.versionSlug }}
+          RELEASE_TITLE: ${{ matrix.name }} ${{ matrix.version }}
+          OUTPUT_DIR: firmware-output/${{ matrix.id }}/${{ matrix.versionSlug }}
+        run: |
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists."
+          else
+            gh release create "$RELEASE_TAG" "$OUTPUT_DIR"/* \
+              --repo "$GITHUB_REPOSITORY" \
+              --target "$GITHUB_SHA" \
+              --title "$RELEASE_TITLE" \
+              --notes "Source-built firmware generated from Registry commit $GITHUB_SHA."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,15 @@ npm-debug.log*
 .env.*
 !.env.example
 
+# Contributor source build output
+integrations/*/source/build/
+integrations/*/source/.cache/
+integrations/*/source/.vscode/
+integrations/*/source/.idea/
+integrations/*/source/managed_components/
+integrations/*/source/sdkconfig
+integrations/*/source/sdkconfig.old
+integrations/*/source/compile_commands.json
+integrations/*/source/*.elf
+integrations/*/source/*.map
+firmware-output/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,12 @@ This repository is the public contribution and review layer for the reTerminal
 Sticky firmware catalog. A completed community contribution becomes a card on
 the Sticky Playground website and opens a Seeed-hosted browser flashing page.
 
-Contributors may submit either a complete buildable source project with its
-firmware package, or a verified firmware-only package with an upstream source
-link. Both paths include metadata, visual assets, and a physical-device test
-record. The private Sticky website reads only a reviewed Registry commit and
-generates the public card and flashing page.
+Contributors may submit either a complete buildable source project, or a
+verified firmware-only package with an upstream source link. For source
+contributions, GitHub Actions builds and packages the firmware. Both paths
+include metadata, visual assets, and a physical-device test record. The private
+Sticky website reads only a reviewed Registry commit and generates the public
+card and flashing page.
 
 For the Chinese guide, see [CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md).
 
@@ -28,8 +29,10 @@ serial connection, flashing interface, domain, and production deployment.
 
 ## Required pull request contents
 
-Create one directory under `integrations/`. The `source/` directory is included
-for a complete-source contribution and omitted for a firmware-only contribution:
+Create one directory under `integrations/`. Choose one of the following package
+layouts.
+
+Source contribution:
 
 ```text
 integrations/
@@ -45,6 +48,18 @@ integrations/
       main/
       components/
       LICENSE
+```
+
+Firmware-only contribution:
+
+```text
+integrations/
+  my-firmware/
+    integration.json
+    README.md
+    assets/
+      logo.svg
+      preview.jpg
     firmware/
       1.0.0/
         manifest.json
@@ -59,10 +74,10 @@ integrations/
 | `README.md` | Firmware behavior, controls, setup, and hardware test record |
 | `assets/logo.*` | Project identity shown by the catalog |
 | `assets/preview.*` | A real screenshot or photo of the firmware running on Sticky |
-| `source/` | Complete source for a complete-source contribution |
+| `source/` | Complete source for a source contribution |
 | `source/LICENSE` | License covering the locally submitted source |
-| `firmware/<version>/manifest.json` | Flash layout, sizes, and SHA-256 values |
-| `firmware/<version>/*.bin` | Ready-to-install firmware files |
+| `firmware/<version>/manifest.json` | Flash layout, sizes, and SHA-256 values for firmware-only contributions |
+| `firmware/<version>/*.bin` | Ready-to-install files for firmware-only contributions |
 
 The directory name and `integration.json.id` use the same lowercase kebab-case
 identifier, such as `weather-dashboard` or `sticky-2048`.
@@ -75,13 +90,13 @@ From the repository root:
 cp -R integrations/_template integrations/my-firmware
 ```
 
-Complete the shared files in this order:
+Complete the files in this order:
 
 1. Rename the directory and update `integration.json.id`.
 2. Add the project README, upstream source URL, and source license name.
 3. Add a logo and an actual device preview under `assets/`.
-4. Place the tested flash package under `firmware/<version>/`.
-5. Add `source/` and `build` metadata when choosing the complete-source path.
+4. For a source contribution, add `source/`, `build` metadata, and `sourceBuild: true`.
+5. For a firmware-only contribution, add the tested package under `firmware/<version>/`.
 6. Run the Registry tests and validator.
 7. Flash the packaged firmware to a physical reTerminal Sticky.
 8. Open a pull request with the test result.
@@ -136,7 +151,7 @@ Normal third-party submissions use `"group": "community"`,
       {
         "version": "1.0.0",
         "channel": "experimental",
-        "manifestPath": "firmware/1.0.0/manifest.json"
+        "sourceBuild": true
       }
     ],
     "notes": [
@@ -159,9 +174,10 @@ Normal third-party submissions use `"group": "community"`,
 | `status` | `experimental`, `beta`, or `stable` according to project maturity |
 | `source.url` | Upstream source repository for both contribution paths |
 | `source.license` | Source license identifier, required for firmware-only contributions |
-| `source.path` | Local source directory for the complete-source path, normally `source` |
+| `source.path` | Local source directory for the source path, normally `source` |
 | `build.*` | Build metadata supplied together with `source.path` |
-| `flash.versions[].manifestPath` | Local manifest under the same integration directory |
+| `flash.versions[].sourceBuild` | Set to `true` when GitHub Actions builds the submitted source |
+| `flash.versions[].manifestPath` | Local manifest used by a firmware-only contribution |
 
 `official` and `platform` catalog sections are maintained through coordinated
 Seeed or partner work. Normal community pull requests target the `community`
@@ -171,11 +187,15 @@ to Sticky Playground.
 
 ## Contribution paths
 
-### Complete source and firmware
+### Source contribution
 
-Include `source/`, set `source.path`, and add the matching `build` object. The
-submitted source and firmware package represent the same release. CI rebuilds
-supported projects and compares the generated files with the submitted package.
+Include `source/`, set `source.path`, add the matching `build` object, and set
+the newest firmware version to `"sourceBuild": true`. GitHub Actions compiles
+the source in a clean environment and creates the manifest and `.bin` files.
+The generated files appear as a temporary PR artifact for review. They are
+published as a versioned GitHub Release after the PR is merged.
+Each project version has one immutable Release, so source updates use a new
+`flash.versions[].version` value.
 
 ### Firmware-only package
 
@@ -192,16 +212,15 @@ result in the integration README and pull request.
 }
 ```
 
-## Complete-source requirements
+## Source contribution requirements
 
-For the complete-source path, the `source/` directory must build independently
+For the source path, the `source/` directory must build independently
 from the submitted files. It includes project build files, application code,
 local components, dependency locks or manifests, default configuration, and the
 applicable license.
 
 Use placeholders or runtime setup for user-specific Wi-Fi credentials, API
-keys, tokens, and passwords. The contributed source and firmware package must
-represent the same release.
+keys, tokens, and passwords.
 
 The first automated build path supports ESP-IDF projects. A typical source tree
 contains:
@@ -209,7 +228,7 @@ contains:
 ```text
 source/
   CMakeLists.txt
-  sdkconfig.defaults  # includes CONFIG_APP_REPRODUCIBLE_BUILD=y
+  sdkconfig.defaults
   main/
     CMakeLists.txt
     main.cpp
@@ -220,32 +239,23 @@ source/
 Projects that need another build system should open an issue first so the
 maintainers can add a reproducible CI build adapter before the firmware PR.
 
-ESP-IDF community projects must enable `CONFIG_APP_REPRODUCIBLE_BUILD=y` in
-`source/sdkconfig.defaults`. This removes build-time and local-path differences,
-allowing CI to confirm that the submitted source produces the packaged firmware.
+The `build.version` field selects the ESP-IDF version used by GitHub Actions.
+Declare the version already used by the project, for example `v5.0.5`, `v5.3.2`,
+or `latest`.
 
-## Build and package ESP-IDF firmware
+## Optional local ESP-IDF build
 
-Install the ESP-IDF version declared in `integration.json`, then run from the
-integration source directory:
+Authors may build locally before opening the PR. Install the ESP-IDF version
+declared in `integration.json`, then run from the integration source directory:
 
 ```bash
 idf.py set-target esp32s3
-idf.py build
+idf.py -D PROJECT_VER=1.0.0 build
 ```
 
-Return to the Registry root and package the exact ESP-IDF flash map:
-
-```bash
-npm run package:esp-idf -- my-firmware 1.0.0
-```
-
-The packaging command reads `source/build/flasher_args.json`, copies every
-required `.bin` file, and creates `firmware/1.0.0/manifest.json` with the flash
-offset, byte size, and SHA-256 for each file.
-
-Commit the generated manifest and `.bin` files together with the source. This
-gives reviewers one reproducible source release and one ready-to-flash package.
+This local build verifies the project before submission. The Registry ignores
+the local `build/`, generated `sdkconfig`, dependency cache, and editor settings.
+GitHub Actions performs the official build and packaging after the PR is opened.
 
 ## Local validation
 
@@ -265,9 +275,12 @@ The validator checks:
 - image file signatures and static SVG safety;
 - local manifest structure;
 - firmware file existence, byte size, and SHA-256;
-- every file and offset from the ESP-IDF flash map;
 - non-overlapping flash address ranges;
 - the direct-flash requirements for community catalog entries.
+
+For source contributions, manifest and firmware-file checks run after GitHub
+Actions builds the project. For firmware-only contributions, they run directly
+against the files committed in the PR.
 
 ## Physical device test
 
@@ -286,12 +299,13 @@ the submitted preview and behavior.
 
 ## Pull request review and automation
 
-The pull request contains the selected contribution path, package, metadata,
-assets, and hardware test result. GitHub Actions performs these checks:
+The pull request contains the selected contribution path, metadata, assets, and
+hardware test result. GitHub Actions performs these checks:
 
-1. Validate the Registry structure and every local firmware package.
-2. Rebuild complete-source ESP-IDF projects in a clean environment.
-3. Compare rebuilt output with every committed `.bin` and SHA-256 for those projects.
+1. Validate the Registry structure and every firmware-only package.
+2. Build source-contribution ESP-IDF projects with each project-declared IDF version.
+3. Generate the flash manifest and firmware package from ESP-IDF's flash map.
+4. Upload the generated package as a temporary PR artifact for maintainer review.
 
 The pull request remains under review until these checks pass and the maintainer
 can verify the project purpose, license, compatibility, and hardware test.
@@ -302,11 +316,12 @@ Merging the Registry pull request does not immediately publish production. The
 maintainer uses the reviewed release flow:
 
 1. Merge the complete Registry pull request.
-2. Update the pinned Registry commit on the Sticky preview branch.
-3. Build Sticky locally and confirm the new card and flashing page.
-4. Flash the firmware from the local Sticky page to a physical device.
-5. Merge the tested Sticky preview branch into Sticky `main`.
-6. Deploy the Sticky website through the company server and Kubernetes.
+2. Wait for the Registry `main` workflow to publish the source-built firmware Release.
+3. Update the pinned Registry commit on the Sticky preview branch.
+4. Build Sticky locally and confirm the new card and flashing page.
+5. Flash the firmware from the local Sticky page to a physical device.
+6. Merge the tested Sticky preview branch into Sticky `main`.
+7. Deploy the Sticky website through the company server and Kubernetes.
 
 This separates contributor review, real-device acceptance, and production
 release while keeping the private website repository closed.
@@ -316,8 +331,8 @@ release while keeping the private website repository closed.
 For a new version:
 
 1. Add the new version to `flash.versions` with the newest version first.
-2. Add the tested package under `firmware/<version>/`.
-3. Update `source/` and run `npm run package:esp-idf -- <id> <version>` when using the complete-source path.
+2. For a source contribution, update `source/` and set the new version to `sourceBuild: true`.
+3. For a firmware-only contribution, add the tested package under `firmware/<version>/`.
 4. Keep older firmware directories referenced by `integration.json`.
 5. Run validation and repeat the physical device test.
 6. Describe user-visible changes and upgrade behavior in the pull request.
@@ -326,8 +341,8 @@ For a new version:
 
 - [ ] One integration directory contains the complete contribution.
 - [ ] `integration.json` uses `community` + `community` + `flash`.
-- [ ] The contribution uses either complete source plus build metadata, or firmware-only plus an upstream source URL and license.
-- [ ] `firmware/<version>/` contains the manifest and every required `.bin`.
+- [ ] The contribution uses either source plus build metadata, or firmware-only plus an upstream source URL and license.
+- [ ] The source path uses `sourceBuild: true`, or the firmware-only path includes the manifest and every required `.bin`.
 - [ ] The README and PR identify the tested package origin and firmware version.
 - [ ] `npm test` and `npm run validate` pass.
 - [ ] The packaged firmware was tested on a physical reTerminal Sticky.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -4,9 +4,10 @@
 一份完整的社区贡献通过审核后，会在 Sticky 官网 Playground 中生成一张固件卡片，
 并进入由 Seeed 网站提供的浏览器烧录页面。
 
-贡献者可以选择提交“完整源码 + 固件包”，也可以只提交经过验证的固件包并提供上游
-源码链接。两种方式都需要项目信息、展示图片和实机测试记录。Sticky 私有网站只读取
-经过审核并锁定版本的公开仓库内容，再生成卡片和烧录页。
+贡献者可以选择提交完整可编译源码，也可以只提交经过验证的固件包并提供上游源码
+链接。源码模式由 GitHub Actions 自动编译并整理固件。两种方式都需要项目信息、展示
+图片和实机测试记录。Sticky 私有网站只读取经过审核并锁定版本的公开仓库内容，再生成
+卡片和烧录页。
 
 英文指南请查看 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
@@ -27,8 +28,9 @@
 
 ## PR 必须提供的文件
 
-每个项目在 `integrations/` 下建立一个独立目录。完整源码模式包含 `source/`，仅固件包
-模式可以省略这个目录：
+每个项目在 `integrations/` 下建立一个独立目录，并从下面两种目录结构中选择一种。
+
+源码模式：
 
 ```text
 integrations/
@@ -44,6 +46,18 @@ integrations/
       main/
       components/
       LICENSE
+```
+
+仅固件包模式：
+
+```text
+integrations/
+  my-firmware/
+    integration.json
+    README.md
+    assets/
+      logo.svg
+      preview.jpg
     firmware/
       1.0.0/
         manifest.json
@@ -58,15 +72,15 @@ integrations/
 | `README.md` | 说明固件功能、操作方式、环境要求和实机测试结果 |
 | `assets/logo.*` | 在固件合集里显示项目标识 |
 | `assets/preview.*` | 展示固件在 Sticky 上真实运行的照片或截图 |
-| `source/` | 完整源码模式使用的可编译工程 |
+| `source/` | 源码模式使用的可编译工程 |
 | `source/LICENSE` | 本地提交源码对应的许可证 |
-| `firmware/<version>/manifest.json` | 记录烧录地址、文件大小和 SHA-256 |
-| `firmware/<version>/*.bin` | 可直接烧录的固件文件 |
+| `firmware/<version>/manifest.json` | 仅固件包模式使用的烧录清单 |
+| `firmware/<version>/*.bin` | 仅固件包模式提交的可烧录文件 |
 
 目录名和 `integration.json` 中的 `id` 必须使用相同的小写连字符格式，例如
 `weather-dashboard` 或 `sticky-2048`。
 
-一句话总结：一个 PR 必须说明“代码在哪里”，并提供用户可以直接烧录的固件包。
+一句话总结：源码模式交源码给 Action 生成固件；仅固件模式直接提交可烧录文件。
 
 ## 创建一份贡献
 
@@ -76,18 +90,18 @@ integrations/
 cp -R integrations/_template integrations/my-firmware
 ```
 
-两种贡献方式都按下面的顺序准备：
+按下面的顺序准备：
 
 1. 修改目录名和 `integration.json.id`。
 2. 在项目 README 和 `integration.json` 中提供上游源码地址与许可证名称。
 3. 在 `assets/` 中加入 Logo 和真实设备效果图。
-4. 把经过测试的固件包放入 `firmware/<version>/`。
-5. 选择完整源码模式时，再加入 `source/` 和对应的 `build` 配置。
+4. 选择源码模式时，加入 `source/`、`build` 配置和 `sourceBuild: true`。
+5. 选择仅固件包模式时，把经过测试的固件包放入 `firmware/<version>/`。
 6. 运行 Registry 测试和校验。
 7. 把这套固件烧录到真实 reTerminal Sticky 上测试。
 8. 提交 Pull Request，并写清测试结果。
 
-一句话总结：源码信息、固件包、页面资料和实机结果齐全后，再进入审核。
+一句话总结：准备项目资料和所选交付方式需要的文件后，再进入审核。
 
 ## integration.json
 
@@ -139,7 +153,7 @@ cp -R integrations/_template integrations/my-firmware
       {
         "version": "1.0.0",
         "channel": "experimental",
-        "manifestPath": "firmware/1.0.0/manifest.json"
+        "sourceBuild": true
       }
     ],
     "notes": [
@@ -162,22 +176,27 @@ cp -R integrations/_template integrations/my-firmware
 | `status` | 按成熟度填写 `experimental`、`beta` 或 `stable` |
 | `source.url` | 两种贡献方式都填写上游源码仓库地址 |
 | `source.license` | 源码许可证名称；仅固件包模式必须填写 |
-| `source.path` | 完整源码模式填写本地源码目录，通常为 `source` |
-| `build.*` | 完整源码模式与 `source.path` 一起提供的构建配置 |
-| `flash.versions[].manifestPath` | 当前项目目录内的 manifest 路径 |
+| `source.path` | 源码模式填写本地源码目录，通常为 `source` |
+| `build.*` | 源码模式与 `source.path` 一起提供的构建配置 |
+| `flash.versions[].sourceBuild` | 源码由 GitHub Actions 编译时设置为 `true` |
+| `flash.versions[].manifestPath` | 仅固件包模式填写项目内的 manifest 路径 |
 
 `official` 和 `platform` 区域由 Seeed 或合作平台共同维护。普通外部 PR 统一进入
 `community` 区域。维护者可以把历史迁移但资料尚未齐全的条目标记为 `draft`；
 草稿不会出现在 Sticky Playground。
 
-一句话总结：社区条目需要有明确源码地址、有本地固件包，并且可以直接烧录。
+一句话总结：社区条目需要有明确源码地址，并通过源码或固件包形成可烧录版本。
 
 ## 两种贡献方式
 
-### 完整源码和固件包
+### 源码模式
 
-提交 `source/`，设置 `source.path`，并加入配套的 `build` 配置。源码和固件包属于同一
-版本。对于已支持的构建系统，CI 会重新编译并把结果与提交的固件逐一比较。
+提交 `source/`，设置 `source.path`，加入配套的 `build` 配置，并把最新版本设置为
+`"sourceBuild": true`。GitHub Actions 会在干净环境中编译源码，自动生成 manifest 和
+全部 `.bin`。PR 阶段会生成临时构建产物供审核；PR 合并后会发布成固定版本的 GitHub
+Release，供 Sticky 测试分支读取。
+每个项目版本只对应一个固定 Release，因此源码更新时需要使用新的
+`flash.versions[].version` 版本号。
 
 ### 仅固件包
 
@@ -192,22 +211,21 @@ cp -R integrations/_template integrations/my-firmware
 }
 ```
 
-一句话总结：有条件时可以提交完整工程，也可以直接提交经过验证的 bin 固件包。
+一句话总结：提交源码时由 Action 产出固件；直接提交固件时由作者提供完整烧录包。
 
-## 完整源码模式要求
+## 源码模式要求
 
-完整源码模式的 `source/` 必须能够仅依靠本次提交的文件完成编译。它应包含工程构建
+源码模式的 `source/` 必须能够仅依靠本次提交的文件完成编译。它应包含工程构建
 文件、应用代码、本地组件、依赖清单或锁定文件、默认配置和许可证。
 
 Wi-Fi 密码、API Key、Token 和密码等用户私密信息使用占位符或首次运行配置方式。
-PR 中的源码和固件包必须属于同一个版本。
 
 第一阶段的自动编译流程支持 ESP-IDF，常见目录如下：
 
 ```text
 source/
   CMakeLists.txt
-  sdkconfig.defaults  # 包含 CONFIG_APP_REPRODUCIBLE_BUILD=y
+  sdkconfig.defaults
   main/
     CMakeLists.txt
     main.cpp
@@ -218,35 +236,26 @@ source/
 需要其他编译系统的项目，先提交 Issue，让维护者先为该编译系统加入可重复执行的 CI
 构建适配，再提交正式固件 PR。
 
-ESP-IDF 社区项目必须在 `source/sdkconfig.defaults` 中启用
-`CONFIG_APP_REPRODUCIBLE_BUILD=y`。这个设置会移除编译时间和本机路径差异，让 CI
-能够确认 PR 中的源码确实可以生成同一套固件包。
+`build.version` 决定 GitHub Actions 使用哪个 ESP-IDF 版本。贡献者填写项目实际使用
+的版本，例如 `v5.0.5`、`v5.3.2` 或 `latest`，流程不会统一锁定到某个固定版本。
 
 一句话总结：源码必须让审核机器能够从零重新编译，而不是只留一个外部链接。
 
-## 编译并整理 ESP-IDF 固件
+## 可选的本地 ESP-IDF 编译
 
-安装 `integration.json` 中声明的 ESP-IDF 版本，然后进入项目的 `source/` 目录执行：
+作者可以在提交 PR 前先做一次本地编译。安装 `integration.json` 中声明的 ESP-IDF
+版本，然后进入项目的 `source/` 目录执行：
 
 ```bash
 idf.py set-target esp32s3
-idf.py build
+idf.py -D PROJECT_VER=1.0.0 build
 ```
 
-编译完成后回到 Registry 仓库根目录，执行：
+这一步用于作者在提交前确认工程能正常编译。Registry 会忽略本地生成的 `build/`、
+`sdkconfig`、依赖缓存和编辑器配置。PR 提交后，正式固件由 GitHub Actions 重新编译
+并整理，无需把本机生成的文件放进 PR。
 
-```bash
-npm run package:esp-idf -- my-firmware 1.0.0
-```
-
-这个命令会读取 `source/build/flasher_args.json`，复制烧录所需的全部 `.bin`，并生成
-`firmware/1.0.0/manifest.json`。manifest 会准确记录每个文件的烧录地址、字节大小和
-SHA-256（通俗解释：用于确认文件没有被替换或损坏的数字指纹）。
-
-生成的 manifest 和 `.bin` 与源码一起提交。审核者因此既能重新编译，也能直接测试
-最终用户将要烧录的同一套文件。
-
-一句话总结：作者负责完成编译，仓库工具负责把编译结果整理成网站能识别的固件包。
+一句话总结：本地编译是可选自测，正式固件统一由 Action 生成。
 
 ## 本地自动检查
 
@@ -265,12 +274,14 @@ npm run validate
 - 设置 `source.path` 时，本地源码目录和 ESP-IDF 工程文件存在；
 - 图片格式正确，SVG 只包含静态内容；
 - manifest 结构正确；
-- 每个固件文件存在，大小和 SHA-256 一致；
-- manifest 包含 ESP-IDF 烧录表中的全部文件和地址；
+- 每个已提交固件文件存在，大小和 SHA-256 一致；
 - 不同固件分区的烧录地址没有重叠；
 - 社区条目满足本站直接烧录的全部要求。
 
 一句话总结：这一步负责提前发现“少文件、固件不匹配、烧录地址错误”等问题。
+
+源码模式的 manifest 和固件文件检查会在 Action 编译后执行；仅固件包模式直接检查
+PR 中提交的文件。
 
 ## 真实设备测试
 
@@ -289,27 +300,29 @@ npm run validate
 
 ## PR 审核和自动编译
 
-PR 需要包含所选贡献方式对应的内容、固件包、项目资料、图片和实机测试结果。
+PR 需要包含所选贡献方式对应的内容、项目资料、图片和实机测试结果。
 GitHub Actions 会依次执行：
 
-1. 检查 Registry 结构和本地固件包。
-2. 在干净环境中重新编译采用完整源码模式的 ESP-IDF 项目。
-3. 对这些项目，把重新编译的结果与 PR 中的每个 `.bin` 和 SHA-256 逐一比较。
+1. 检查 Registry 结构和仅固件包模式提交的文件。
+2. 按每个源码项目声明的 ESP-IDF 版本进行编译。
+3. 根据 ESP-IDF 烧录表自动生成 manifest 和完整固件包。
+4. 把生成的固件作为 PR 临时构建产物，供维护者下载审核。
 
 当这些检查通过，并且维护者确认项目用途、许可证、兼容性和实机结果后，PR 才进入合并。
 
-一句话总结：作者提供成品，自动流程证明“源码确实能生成这套成品”。
+一句话总结：作者提交源码，自动流程负责生成可审核的固件成品。
 
 ## 合并后如何进入 Sticky 官网
 
 Registry PR 合并后不会立刻进入正式生产站。维护者按照下面的顺序发布：
 
 1. 合并资料完整且检查通过的 Registry PR。
-2. 在 Sticky 固定测试分支更新所锁定的 Registry 提交。
-3. 本地构建 Sticky，确认新卡片和烧录页面正确生成。
-4. 从本地 Sticky 页面把固件烧录到真实设备并验收。
-5. 把测试通过的 Sticky 分支合并到 Sticky `main`。
-6. 由公司服务器构建网站，并通过 Kubernetes 发布。
+2. 等待 Registry `main` 的 Action 发布源码编译固件 Release。
+3. 在 Sticky 固定测试分支更新所锁定的 Registry 提交。
+4. 本地构建 Sticky，确认新卡片和烧录页面正确生成。
+5. 从本地 Sticky 页面把固件烧录到真实设备并验收。
+6. 把测试通过的 Sticky 分支合并到 Sticky `main`。
+7. 由公司服务器构建网站，并通过 Kubernetes 发布。
 
 这条流程把“外部贡献审核”“实机验收”和“正式上线”分成三个明确阶段，同时保持
 Sticky 网站仓库闭源。
@@ -321,20 +334,20 @@ Sticky 网站仓库闭源。
 发布新版本时：
 
 1. 在 `flash.versions` 最前面加入新版本。
-2. 把经过测试的固件包放入 `firmware/<version>/`。
-3. 完整源码模式同时更新 `source/`，并执行 `npm run package:esp-idf -- <id> <version>`。
+2. 源码模式更新 `source/`，并把新版本设置为 `sourceBuild: true`。
+3. 仅固件包模式把经过测试的固件包放入 `firmware/<version>/`。
 4. 保留仍被 `integration.json` 引用的旧版本目录。
 5. 重新运行自动检查和真实设备测试。
 6. 在 PR 中说明用户能看到的变化和升级后的行为。
 
-一句话总结：每个版本都保留固件包和测试结果；完整源码模式同时保留对应源码。
+一句话总结：每个版本保留测试结果；源码模式的历史固件保存在对应 GitHub Release。
 
 ## PR 提交前清单
 
 - [ ] 一个项目目录包含本次完整贡献。
 - [ ] `integration.json` 使用 `community` + `community` + `flash`。
-- [ ] 已选择“完整源码 + 构建配置”或“仅固件包 + 上游源码地址与许可证”。
-- [ ] `firmware/<version>/` 包含 manifest 和全部必需 `.bin`。
+- [ ] 已选择“源码 + 构建配置”或“仅固件包 + 上游源码地址与许可证”。
+- [ ] 源码模式使用 `sourceBuild: true`，或仅固件包模式包含 manifest 和全部必需 `.bin`。
 - [ ] README 和 PR 写明经过测试的固件来源和固件版本。
 - [ ] `npm test` 和 `npm run validate` 全部通过。
 - [ ] 这套固件已在真实 reTerminal Sticky 上完成测试。

--- a/README.md
+++ b/README.md
@@ -4,18 +4,21 @@ Public firmware contribution and review repository for the reTerminal Sticky
 Playground.
 
 The Sticky website repository remains private. Community developers contribute
-ready-to-flash firmware, metadata, visual assets, and either complete buildable
-source or an upstream source reference here. The Sticky website pins a reviewed
-Registry commit, mirrors its verified firmware files, and generates the public
-catalog cards and browser flashing pages.
+metadata, visual assets, and either complete buildable source or a verified
+firmware package here. GitHub Actions builds source contributions and publishes
+their installable files. The Sticky website pins a reviewed Registry commit,
+mirrors its verified firmware files, and generates the public catalog cards and
+browser flashing pages.
 
 ## Published community flow
 
 ```text
 Contributor PR
-  -> source reference + firmware + manifest + assets
-  -> Registry validation and optional clean rebuild
+  -> source project or firmware-only package + metadata + assets
+  -> Registry validation and source build
+  -> PR artifact for review
   -> maintainer review and merge
+  -> versioned firmware Release
   -> Sticky preview branch pins the Registry commit
   -> local page and physical-device flash test
   -> Sticky main and Kubernetes deployment
@@ -33,8 +36,8 @@ integrations/
     integration.json
     README.md
     assets/
-    source/  # complete-source contributions
-    firmware/
+    source/  # source contributions
+    firmware/  # firmware-only contributions
       <version>/
         manifest.json
         *.bin
@@ -55,21 +58,16 @@ npm test
 npm run validate
 ```
 
-For an ESP-IDF project that has already been built under its `source/`
-directory:
-
-```bash
-npm run package:esp-idf -- <integration-id> <version>
-```
-
-This command packages the exact ESP-IDF flash map and generates the local
-manifest used by the Sticky browser flasher.
+For source contributions, declare the project's ESP-IDF version in
+`integration.json` and set the newest firmware version to `sourceBuild: true`.
+GitHub Actions builds the project, packages ESP-IDF's flash map, and publishes
+the firmware after merge.
 
 ## Contribution guides
 
 - [English contribution guide](CONTRIBUTING.md)
 - [中文贡献指南](CONTRIBUTING.zh-CN.md)
 
-The guides define the complete-source and firmware-only contribution paths,
+The guides define the source and firmware-only contribution paths,
 firmware package, metadata, local validation, physical-device test, pull request
 checks, and post-merge Sticky release flow.

--- a/integrations/_template/README.md
+++ b/integrations/_template/README.md
@@ -3,9 +3,10 @@
 Copy this directory to `integrations/<integration-id>/`, then provide:
 
 1. Complete metadata in `integration.json`.
-2. Either a licensed, reproducible project under `source/`, or an upstream
-   source URL and license for a firmware-only contribution.
-3. The packaged firmware and manifest under `firmware/<version>/`.
+2. A licensed, reproducible ESP-IDF project under `source/`. GitHub Actions
+   builds and packages the firmware for this contribution mode.
+3. For a firmware-only contribution, an upstream source URL and license plus
+   the packaged files under `firmware/<version>/`.
 4. A project logo and a real Sticky preview under `assets/`.
 5. The package origin, firmware behavior, and physical-device test result in
    this README.

--- a/integrations/_template/firmware/README.md
+++ b/integrations/_template/firmware/README.md
@@ -1,10 +1,7 @@
 # Firmware packages
 
-Create one directory per version. After building the source project, run:
+This directory is used by firmware-only contributions. Create one directory per
+version and include `manifest.json` plus every `.bin` file referenced by it.
 
-```bash
-npm run package:esp-idf -- <integration-id> <version>
-```
-
-Commit the generated `manifest.json` and every `.bin` file required by the
-manifest.
+For source contributions, set `sourceBuild: true` in `integration.json` and
+place the project under `source/`. GitHub Actions produces the firmware package.

--- a/integrations/_template/integration.json
+++ b/integrations/_template/integration.json
@@ -47,7 +47,7 @@
       {
         "version": "1.0.0",
         "channel": "stable",
-        "manifestPath": "firmware/1.0.0/manifest.json"
+        "sourceBuild": true
       }
     ]
   }

--- a/integrations/_template/source/README.md
+++ b/integrations/_template/source/README.md
@@ -2,5 +2,5 @@
 
 Place the complete ESP-IDF project in this directory. Include `CMakeLists.txt`,
 `sdkconfig.defaults`, application code, local components, dependency metadata,
-and the applicable license. Keep `CONFIG_APP_REPRODUCIBLE_BUILD=y` in
-`sdkconfig.defaults` so CI can reproduce the packaged firmware exactly.
+and the applicable license. GitHub Actions uses the ESP-IDF version declared in
+`integration.json` to build this project and package its flash files.

--- a/schemas/integration.schema.json
+++ b/schemas/integration.schema.json
@@ -586,6 +586,11 @@
         },
         "manifestPath": {
           "$ref": "#/$defs/localPath"
+        },
+        "sourceBuild": {
+          "type": "boolean",
+          "const": true,
+          "description": "Build and publish this version from the submitted source with GitHub Actions."
         }
       },
       "oneOf": [
@@ -599,6 +604,11 @@
             "manifestUrl",
             "manifestSha256",
             "releaseUrl"
+          ]
+        },
+        {
+          "required": [
+            "sourceBuild"
           ]
         }
       ]

--- a/scripts/list-build-targets.mjs
+++ b/scripts/list-build-targets.mjs
@@ -3,8 +3,22 @@
 import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
-const ROOT_DIR = resolve(import.meta.dirname, '..');
+const ROOT_DIR = process.env.REGISTRY_ROOT
+  ? resolve(process.env.REGISTRY_ROOT)
+  : resolve(import.meta.dirname, '..');
 const INTEGRATIONS_DIR = join(ROOT_DIR, 'integrations');
+
+function slugifyVersion(value) {
+  const slug = String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9.]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (!slug || !/^[a-z0-9][a-z0-9.-]*$/.test(slug)) {
+    throw new Error(`Cannot create a safe version slug from "${value}"`);
+  }
+  return slug;
+}
 
 const targets = readdirSync(INTEGRATIONS_DIR, { withFileTypes: true })
   .filter((entry) => entry.isDirectory() && !entry.name.startsWith('_'))
@@ -13,12 +27,20 @@ const targets = readdirSync(INTEGRATIONS_DIR, { withFileTypes: true })
       join(INTEGRATIONS_DIR, entry.name, 'integration.json'),
       'utf8',
     ));
-    if (integration.build?.system !== 'esp-idf') return null;
+    const version = integration.flash?.versions?.[0];
+    if (
+      integration.build?.system !== 'esp-idf'
+      || integration.catalogSection === 'draft'
+      || version?.sourceBuild !== true
+    ) return null;
     return {
       id: integration.id,
+      name: integration.name,
       path: `integrations/${integration.id}/${integration.build.projectPath}`,
       idfVersion: integration.build.version,
       target: integration.build.target,
+      version: version.version,
+      versionSlug: slugifyVersion(version.version),
     };
   })
   .filter(Boolean);

--- a/scripts/list-build-targets.test.mjs
+++ b/scripts/list-build-targets.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const LIST_SCRIPT = join(SCRIPT_DIR, 'list-build-targets.mjs');
+
+function writeIntegration(root, integration) {
+  const integrationDir = join(root, 'integrations', integration.id);
+  mkdirSync(integrationDir, { recursive: true });
+  writeFileSync(
+    join(integrationDir, 'integration.json'),
+    `${JSON.stringify(integration, null, 2)}\n`,
+  );
+}
+
+test('lists only publishable source-built integrations', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sticky-target-list-test-'));
+  try {
+    writeIntegration(root, {
+      id: 'source-project',
+      name: 'Source Project',
+      catalogSection: 'community',
+      build: {
+        system: 'esp-idf',
+        version: 'v5.3.2',
+        target: 'esp32s3',
+        projectPath: 'source',
+      },
+      flash: {
+        versions: [{ version: '2.0.0 RC1', sourceBuild: true }],
+      },
+    });
+    writeIntegration(root, {
+      id: 'firmware-only',
+      name: 'Firmware Only',
+      catalogSection: 'community',
+      flash: {
+        versions: [{
+          version: '1.0.0',
+          manifestPath: 'firmware/1.0.0/manifest.json',
+        }],
+      },
+    });
+    writeIntegration(root, {
+      id: 'draft-source',
+      name: 'Draft Source',
+      catalogSection: 'draft',
+      build: {
+        system: 'esp-idf',
+        version: 'v5.4.1',
+        target: 'esp32s3',
+        projectPath: 'source',
+      },
+      flash: {
+        versions: [{ version: '1.0.0', sourceBuild: true }],
+      },
+    });
+
+    const result = spawnSync(process.execPath, [LIST_SCRIPT], {
+      encoding: 'utf8',
+      env: { ...process.env, REGISTRY_ROOT: root },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), {
+      include: [{
+        id: 'source-project',
+        name: 'Source Project',
+        path: 'integrations/source-project/source',
+        idfVersion: 'v5.3.2',
+        target: 'esp32s3',
+        version: '2.0.0 RC1',
+        versionSlug: '2.0.0-rc1',
+      }],
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/package-esp-idf.mjs
+++ b/scripts/package-esp-idf.mjs
@@ -27,14 +27,23 @@ if (integration.id !== integrationId || integration.build?.system !== 'esp-idf')
 }
 
 const version = integration.flash?.versions?.find((entry) => entry.version === versionLabel);
-if (!version?.manifestPath) {
-  throw new Error(`${integrationId} ${versionLabel} must define flash.versions[].manifestPath`);
+if (!version) {
+  throw new Error(`${integrationId} does not define firmware version ${versionLabel}`);
+}
+if (!version.manifestPath && version.sourceBuild !== true) {
+  throw new Error(`${integrationId} ${versionLabel} does not define a package destination`);
 }
 
 const projectDir = join(integrationDir, integration.build.projectPath);
 const buildDir = join(projectDir, 'build');
 const flashArgs = JSON.parse(readFileSync(join(buildDir, 'flasher_args.json'), 'utf8'));
-const outputDir = join(integrationDir, dirname(version.manifestPath));
+const configuredOutputDir = process.env.FIRMWARE_OUTPUT_DIR;
+if (version.sourceBuild === true && !configuredOutputDir) {
+  throw new Error('FIRMWARE_OUTPUT_DIR is required for a source-built firmware package');
+}
+const outputDir = configuredOutputDir
+  ? resolve(configuredOutputDir)
+  : join(integrationDir, dirname(version.manifestPath));
 mkdirSync(outputDir, { recursive: true });
 const packagedNames = new Set();
 
@@ -65,6 +74,7 @@ if (parts.length === 0) {
 }
 
 const manifest = {
+  integrationId: integration.id,
   name: integration.name,
   version: versionLabel,
   flashSize: flashArgs.flash_settings?.flash_size,
@@ -76,8 +86,15 @@ const manifest = {
   ],
 };
 
+if (process.env.REGISTRY_COMMIT) {
+  if (!/^[a-f0-9]{40}$/.test(process.env.REGISTRY_COMMIT)) {
+    throw new Error('REGISTRY_COMMIT must be a full lowercase commit SHA');
+  }
+  manifest.registryCommit = process.env.REGISTRY_COMMIT;
+}
+
 writeFileSync(
-  join(integrationDir, version.manifestPath),
+  join(outputDir, 'manifest.json'),
   `${JSON.stringify(manifest, null, 2)}\n`,
   'utf8',
 );

--- a/scripts/package-esp-idf.test.mjs
+++ b/scripts/package-esp-idf.test.mjs
@@ -98,3 +98,82 @@ test('packages and verifies an ESP-IDF flash map', () => {
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test('packages a source-built firmware into an Action output directory', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sticky-source-package-test-'));
+  try {
+    const integrationDir = join(root, 'integrations', 'source-firmware');
+    const buildDir = join(integrationDir, 'source', 'build');
+    const outputDir = join(root, '.firmware-output', 'source-firmware', '2.0.0-rc1');
+    mkdirSync(join(buildDir, 'partition_table'), { recursive: true });
+    writeFileSync(
+      join(integrationDir, 'integration.json'),
+      `${JSON.stringify({
+        id: 'source-firmware',
+        name: 'Source Firmware',
+        build: {
+          system: 'esp-idf',
+          projectPath: 'source',
+        },
+        flash: {
+          versions: [{
+            version: '2.0.0-rc1',
+            sourceBuild: true,
+          }],
+        },
+      }, null, 2)}\n`,
+    );
+
+    const partitionTable = Buffer.from([0xaa, 0xbb, 0xcc]);
+    const application = Buffer.from([0xe9, 0x06, 0x07, 0x08]);
+    writeFileSync(join(buildDir, 'partition_table', 'partition-table.bin'), partitionTable);
+    writeFileSync(join(buildDir, 'source.bin'), application);
+    writeFileSync(
+      join(buildDir, 'flasher_args.json'),
+      `${JSON.stringify({
+        flash_files: {
+          '0x8000': 'partition_table/partition-table.bin',
+          '0x10000': 'source.bin',
+        },
+        flash_settings: {
+          flash_size: '8MB',
+        },
+      }, null, 2)}\n`,
+    );
+
+    const registryCommit = 'c'.repeat(40);
+    const packageResult = spawnSync(
+      process.execPath,
+      [PACKAGE_SCRIPT, 'source-firmware', '2.0.0-rc1'],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          REGISTRY_ROOT: root,
+          FIRMWARE_OUTPUT_DIR: outputDir,
+          REGISTRY_COMMIT: registryCommit,
+        },
+      },
+    );
+    assert.equal(packageResult.status, 0, packageResult.stderr);
+
+    const manifest = JSON.parse(readFileSync(join(outputDir, 'manifest.json'), 'utf8'));
+    assert.equal(manifest.integrationId, 'source-firmware');
+    assert.equal(manifest.registryCommit, registryCommit);
+    assert.equal(manifest.version, '2.0.0-rc1');
+    assert.equal(manifest.flashSize, '8MB');
+    assert.deepEqual(
+      manifest.builds[0].parts.map((part) => [part.path, part.offset]),
+      [
+        ['partition-table.bin', 32768],
+        ['source.bin', 65536],
+      ],
+    );
+    assert.equal(
+      manifest.builds[0].parts[0].sha256,
+      createHash('sha256').update(partitionTable).digest('hex'),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -204,29 +204,6 @@ function validateBuild(value, integrationDir, source, scope) {
   }
 }
 
-function validateReproducibleEspIdfBuild(projectPath, integrationDir, scope) {
-  if (!projectPath) {
-    return;
-  }
-
-  const defaultsPath = validateLocalFilePath(
-    join(projectPath, 'sdkconfig.defaults'),
-    integrationDir,
-    `${scope}.sdkconfig.defaults`,
-  );
-  if (!defaultsPath) {
-    return;
-  }
-
-  const defaults = readFileSync(defaultsPath, 'utf8');
-  if (!/^CONFIG_APP_REPRODUCIBLE_BUILD=y\s*$/m.test(defaults)) {
-    addError(
-      `${scope}.sdkconfig.defaults`,
-      'must enable CONFIG_APP_REPRODUCIBLE_BUILD=y',
-    );
-  }
-}
-
 function validateCommunityProjectFiles(integrationDir, sourcePath, scope) {
   validateLocalFilePath('README.md', integrationDir, `${scope}.README.md`);
   if (sourcePath) {
@@ -612,6 +589,7 @@ function validateFlashMode(value, integrationDir, scope) {
       'manifestSha256',
       'releaseUrl',
       'manifestPath',
+      'sourceBuild',
     ]);
     const requiredVersionKeys = ['version', 'channel'];
     if (!validateObjectKeys(entry, requiredVersionKeys, allowedVersionKeys, versionScope)) {
@@ -626,11 +604,21 @@ function validateFlashMode(value, integrationDir, scope) {
     }
 
     validateEnum(entry.channel, ALLOWED_STATUSES, `${versionScope}.channel`);
+    const deliveryFields = [
+      entry.manifestPath !== undefined,
+      entry.manifestUrl !== undefined || entry.manifestSha256 !== undefined || entry.releaseUrl !== undefined,
+      entry.sourceBuild === true,
+    ].filter(Boolean).length;
+    if (deliveryFields !== 1) {
+      addError(versionScope, 'must use exactly one firmware delivery method');
+      return;
+    }
+
     if (entry.manifestPath !== undefined) {
-      if (entry.manifestUrl !== undefined || entry.manifestSha256 !== undefined || entry.releaseUrl !== undefined) {
-        addError(versionScope, 'must use either manifestPath or remote manifest fields');
-      }
       validateLocalFlashManifest(entry.manifestPath, integrationDir, entry.version, `${versionScope}.manifestPath`);
+    } else if (entry.sourceBuild === true) {
+      // GitHub Actions creates the manifest and firmware release from source.
+      // GitHub Actions 会根据源码生成 manifest 和固件 Release。
     } else {
       validateHttpsUrl(entry.manifestUrl, `${versionScope}.manifestUrl`);
       validateString(entry.manifestSha256, `${versionScope}.manifestSha256`, {
@@ -759,16 +747,15 @@ function validateIntegration(integrationDir, directoryName, seenIds) {
     if (!hasLocalSource && !integration.source?.license) {
       addError(`${scope}.source.license`, 'is required for firmware-only contributions');
     }
-    if (hasBuildConfig && integration.build.system === 'esp-idf') {
-      validateReproducibleEspIdfBuild(
-        integration.build.projectPath,
-        integrationDir,
-        `${scope}.build`,
-      );
+    const versions = integration.flash?.versions || [];
+    if (hasLocalSource && versions[0]?.sourceBuild !== true) {
+      addError(`${scope}.flash.versions[0].sourceBuild`, 'must be true for a source contribution');
     }
-    for (const [index, version] of (integration.flash?.versions || []).entries()) {
-      if (!version.manifestPath) {
-        addError(`${scope}.flash.versions[${index}].manifestPath`, 'is required for community firmware');
+    if (!hasLocalSource) {
+      for (const [index, version] of versions.entries()) {
+        if (!version.manifestPath) {
+          addError(`${scope}.flash.versions[${index}].manifestPath`, 'is required for a firmware-only contribution');
+        }
       }
     }
   }

--- a/scripts/validate-registry.test.mjs
+++ b/scripts/validate-registry.test.mjs
@@ -220,7 +220,7 @@ test('accepts a valid flash integration', () => {
   assert.equal(result.status, 0);
 });
 
-test('accepts a community firmware with local source and verified binaries', () => {
+test('accepts a community source contribution without committed firmware', () => {
   const root = createRegistry();
   const integration = validBase('community-firmware', 'flash');
   integration.catalogSection = 'community';
@@ -235,7 +235,7 @@ test('accepts a community firmware with local source and verified binaries', () 
     versions: [{
       version: '1.0.0',
       channel: 'stable',
-      manifestPath: 'firmware/1.0.0/manifest.json',
+      sourceBuild: true,
     }],
   };
   const integrationDir = writeIntegration(root, integration);
@@ -243,27 +243,6 @@ test('accepts a community firmware with local source and verified binaries', () 
   mkdirSync(join(integrationDir, 'source'), { recursive: true });
   writeFileSync(join(integrationDir, 'source', 'CMakeLists.txt'), 'project(example)\n');
   writeFileSync(join(integrationDir, 'source', 'LICENSE'), 'MIT License\n');
-  writeFileSync(
-    join(integrationDir, 'source', 'sdkconfig.defaults'),
-    'CONFIG_APP_REPRODUCIBLE_BUILD=y\n',
-  );
-  mkdirSync(join(integrationDir, 'firmware', '1.0.0'), { recursive: true });
-  const binary = Buffer.from([0xe9, 0x01, 0x02, 0x03]);
-  const sha256 = createHash('sha256').update(binary).digest('hex');
-  writeFileSync(join(integrationDir, 'firmware', '1.0.0', 'firmware.bin'), binary);
-  writeFileSync(
-    join(integrationDir, 'firmware', '1.0.0', 'manifest.json'),
-    `${JSON.stringify({
-      name: 'Community Firmware',
-      version: '1.0.0',
-      flashSize: '16MB',
-      builds: [{
-        chipFamily: 'ESP32-S3',
-        parts: [{ path: 'firmware.bin', offset: 65536, size: binary.length, sha256 }],
-      }],
-    }, null, 2)}\n`,
-  );
-
   const result = runValidator(root);
 
   assert.equal(result.status, 0, result.stderr);
@@ -334,78 +313,17 @@ test('rejects a community contribution with local source but no build config', (
     versions: [{
       version: '1.0.0',
       channel: 'stable',
-      manifestPath: 'firmware/1.0.0/manifest.json',
+      sourceBuild: true,
     }],
   };
   const integrationDir = writeIntegration(root, integration);
   writeFileSync(join(integrationDir, 'README.md'), '# Incomplete source contribution\n');
   mkdirSync(join(integrationDir, 'source'), { recursive: true });
   writeFileSync(join(integrationDir, 'source', 'LICENSE'), 'MIT License\n');
-  mkdirSync(join(integrationDir, 'firmware', '1.0.0'), { recursive: true });
-  const binary = Buffer.from([0xe9, 0x01]);
-  const sha256 = createHash('sha256').update(binary).digest('hex');
-  writeFileSync(join(integrationDir, 'firmware', '1.0.0', 'firmware.bin'), binary);
-  writeFileSync(
-    join(integrationDir, 'firmware', '1.0.0', 'manifest.json'),
-    `${JSON.stringify({
-      name: 'Incomplete source contribution',
-      version: '1.0.0',
-      builds: [{
-        chipFamily: 'ESP32-S3',
-        parts: [{ path: 'firmware.bin', offset: 65536, size: binary.length, sha256 }],
-      }],
-    }, null, 2)}\n`,
-  );
-
   const result = runValidator(root);
 
   assert.equal(result.status, 1);
   assert.match(result.stderr, /build: is required when source\.path is provided/);
-});
-
-test('rejects a community ESP-IDF build without reproducible output', () => {
-  const root = createRegistry();
-  const integration = validBase('non-reproducible-firmware', 'flash');
-  integration.catalogSection = 'community';
-  integration.source.path = 'source';
-  integration.build = {
-    system: 'esp-idf',
-    version: 'latest',
-    target: 'esp32s3',
-    projectPath: 'source',
-  };
-  integration.flash = {
-    versions: [{
-      version: '1.0.0',
-      channel: 'stable',
-      manifestPath: 'firmware/1.0.0/manifest.json',
-    }],
-  };
-  const integrationDir = writeIntegration(root, integration);
-  writeFileSync(join(integrationDir, 'README.md'), '# Non-reproducible Firmware\n');
-  mkdirSync(join(integrationDir, 'source'), { recursive: true });
-  writeFileSync(join(integrationDir, 'source', 'CMakeLists.txt'), 'project(example)\n');
-  writeFileSync(join(integrationDir, 'source', 'LICENSE'), 'MIT License\n');
-  mkdirSync(join(integrationDir, 'firmware', '1.0.0'), { recursive: true });
-  const binary = Buffer.from([0xe9, 0x01]);
-  const sha256 = createHash('sha256').update(binary).digest('hex');
-  writeFileSync(join(integrationDir, 'firmware', '1.0.0', 'firmware.bin'), binary);
-  writeFileSync(
-    join(integrationDir, 'firmware', '1.0.0', 'manifest.json'),
-    `${JSON.stringify({
-      name: 'Non-reproducible Firmware',
-      version: '1.0.0',
-      builds: [{
-        chipFamily: 'ESP32-S3',
-        parts: [{ path: 'firmware.bin', offset: 65536, size: binary.length, sha256 }],
-      }],
-    }, null, 2)}\n`,
-  );
-
-  const result = runValidator(root);
-
-  assert.equal(result.status, 1);
-  assert.match(result.stderr, /sdkconfig\.defaults: references a missing file/);
 });
 
 test('rejects a non-flash community catalog entry', () => {


### PR DESCRIPTION
## Summary

- add a source contribution mode where contributors submit buildable ESP-IDF source without committed firmware binaries
- build and package source contributions with each project-declared ESP-IDF version in GitHub Actions
- upload temporary firmware artifacts for pull request review and publish immutable versioned Releases after merge
- retain the existing firmware-only contribution path with local manifest and binary verification
- ignore local ESP-IDF build output, generated configuration, dependency caches, and editor settings
- update the templates, pull request checklist, README, and bilingual contribution guides

## Release flow

1. A contributor submits source, metadata, assets, and `sourceBuild: true`.
2. GitHub Actions validates the Registry and builds the ESP-IDF project.
3. The workflow packages ESP-IDF's flash map into a manifest and firmware artifact.
4. Pull requests receive a temporary review artifact.
5. Merges to `main` publish an immutable `registry-<integration-id>-<version>` Release.

Firmware-only contributions continue to provide `manifest.json` and the referenced `.bin` files under `firmware/<version>/`.

## Validation

- `npm test` - 17 tests passed
- `npm run validate` - 3 integrations passed
- workflow YAML parsed successfully
- `git diff --check` passed
