### PR TITLE
feat: improve community firmware attribution and assets

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,7 +30,7 @@ List the commands and manual checks completed for this contribution.
 - [ ] The integration directory and `id` use the same lowercase kebab-case name.
 - [ ] The integration README identifies the package origin and firmware version.
 - [ ] The author, source, support, and documentation links are current.
-- [ ] The logo and preview image are included, or the existing approved assets are reused unchanged.
+- [ ] The required preview image is included; an optional logo is included when the integration needs one.
 - [ ] The submitted files contain no user-specific credentials, API keys, tokens, passwords, or private keys.
 - [ ] The selected package type has all required source or firmware files.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,7 +29,7 @@ List the commands and manual checks completed for this contribution.
 - [ ] `npm run validate` passes locally.
 - [ ] The integration directory and `id` use the same lowercase kebab-case name.
 - [ ] The integration README identifies the package origin and firmware version.
-- [ ] The author, source, support, and documentation links are current.
+- [ ] The author name and any provided author, display source, support, and documentation links are current.
 - [ ] The required preview image is included; an optional logo is included when the integration needs one.
 - [ ] The submitted files contain no user-specific credentials, API keys, tokens, passwords, or private keys.
 - [ ] The selected package type has all required source or firmware files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,13 +97,14 @@ cp -R integrations/_template integrations/my-firmware
 Complete the files in this order:
 
 1. Rename the directory and update `integration.json.id`.
-2. Add the project README, upstream source URL, and source license name.
-3. Add an actual device preview under `assets/`, plus a project logo when needed.
-4. For a source contribution, add `source/`, `build` metadata, and `sourceBuild: true`.
-5. For a firmware-only contribution, add the tested package under `firmware/<version>/`.
-6. Run the Registry tests and validator.
-7. Flash the packaged firmware to a physical reTerminal Sticky.
-8. Open a pull request with the test result.
+2. Add the required author name, an optional author link, and an optional display source.
+3. Add the project README, upstream source URL, and source license name.
+4. Add an actual device preview under `assets/`, plus a project logo when needed.
+5. For a source contribution, add `source/`, `build` metadata, and `sourceBuild: true`.
+6. For a firmware-only contribution, add the tested package under `firmware/<version>/`.
+7. Run the Registry tests and validator.
+8. Flash the packaged firmware to a physical reTerminal Sticky.
+9. Open a pull request with the test result.
 
 ## integration.json
 
@@ -124,6 +125,10 @@ Normal third-party submissions use `"group": "community"`,
   "author": {
     "name": "Project author or team",
     "url": "https://github.com/example"
+  },
+  "origin": {
+    "name": "Project repository",
+    "url": "https://github.com/example/my-firmware"
   },
   "source": {
     "url": "https://github.com/example/my-firmware",
@@ -175,12 +180,20 @@ Normal third-party submissions use `"group": "community"`,
 | `catalogSection` | `community` |
 | `mode` | `flash` |
 | `status` | `experimental`, `beta`, or `stable` according to project maturity |
+| `author.name` | Required author or team name shown on the website |
+| `author.url` | Optional HTTPS link opened when the author name is selected |
+| `origin.name` | Optional display source shown on the website |
+| `origin.url` | Optional HTTPS link opened when the display source is selected |
 | `source.url` | Upstream source repository for both contribution paths |
 | `source.license` | Source license identifier, required for firmware-only contributions |
 | `source.path` | Local source directory for the source path, normally `source` |
 | `build.*` | Build metadata supplied together with `source.path` |
 | `flash.versions[].sourceBuild` | Set to `true` when GitHub Actions builds the submitted source |
 | `flash.versions[].manifestPath` | Local manifest used by a firmware-only contribution |
+
+`author` and `origin` are website attribution fields. The `source` object keeps
+the technical source repository, license, and local build path used during
+review and packaging.
 
 `official` and `platform` catalog sections are maintained through coordinated
 Seeed or partner work. Normal community pull requests target the `community`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,8 @@ integrations/
     integration.json
     README.md
     assets/
-      logo.svg
       preview.jpg
+      logo.svg  # optional
     source/
       CMakeLists.txt
       sdkconfig.defaults
@@ -58,8 +58,8 @@ integrations/
     integration.json
     README.md
     assets/
-      logo.svg
       preview.jpg
+      logo.svg  # optional
     firmware/
       1.0.0/
         manifest.json
@@ -72,7 +72,7 @@ integrations/
 |---|---|
 | `integration.json` | Card text, author, compatibility, build settings, and firmware versions |
 | `README.md` | Firmware behavior, controls, setup, and hardware test record |
-| `assets/logo.*` | Project identity shown by the catalog |
+| `assets/logo.*` | Optional project identity asset |
 | `assets/preview.*` | A real screenshot or photo of the firmware running on Sticky |
 | `source/` | Complete source for a source contribution |
 | `source/LICENSE` | License covering the locally submitted source |
@@ -81,6 +81,10 @@ integrations/
 
 The directory name and `integration.json.id` use the same lowercase kebab-case
 identifier, such as `weather-dashboard` or `sticky-2048`.
+
+Images under `integrations/<integration-id>/assets/` may use `.png`, `.jpg`,
+`.jpeg`, `.webp`, or static `.svg` files. The preview image is required; the
+project logo is optional.
 
 ## Create a contribution
 
@@ -94,7 +98,7 @@ Complete the files in this order:
 
 1. Rename the directory and update `integration.json.id`.
 2. Add the project README, upstream source URL, and source license name.
-3. Add a logo and an actual device preview under `assets/`.
+3. Add an actual device preview under `assets/`, plus a project logo when needed.
 4. For a source contribution, add `source/`, `build` metadata, and `sourceBuild: true`.
 5. For a firmware-only contribution, add the tested package under `firmware/<version>/`.
 6. Run the Registry tests and validator.
@@ -135,7 +139,6 @@ Normal third-party submissions use `"group": "community"`,
     "notes": "Tested on reTerminal Sticky production hardware."
   },
   "assets": {
-    "logo": "assets/logo.svg",
     "preview": "assets/preview.jpg",
     "previewAlt": "My Firmware running on reTerminal Sticky"
   },

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -38,8 +38,8 @@ integrations/
     integration.json
     README.md
     assets/
-      logo.svg
       preview.jpg
+      logo.svg  # 可选
     source/
       CMakeLists.txt
       sdkconfig.defaults
@@ -56,8 +56,8 @@ integrations/
     integration.json
     README.md
     assets/
-      logo.svg
       preview.jpg
+      logo.svg  # 可选
     firmware/
       1.0.0/
         manifest.json
@@ -70,7 +70,7 @@ integrations/
 |---|---|
 | `integration.json` | 保存卡片文案、作者、兼容性、编译方式和固件版本 |
 | `README.md` | 说明固件功能、操作方式、环境要求和实机测试结果 |
-| `assets/logo.*` | 在固件合集里显示项目标识 |
+| `assets/logo.*` | 可选的项目标识图片 |
 | `assets/preview.*` | 展示固件在 Sticky 上真实运行的照片或截图 |
 | `source/` | 源码模式使用的可编译工程 |
 | `source/LICENSE` | 本地提交源码对应的许可证 |
@@ -79,6 +79,10 @@ integrations/
 
 目录名和 `integration.json` 中的 `id` 必须使用相同的小写连字符格式，例如
 `weather-dashboard` 或 `sticky-2048`。
+
+`integrations/<integration-id>/assets/` 下的图片支持 `.png`、`.jpg`、
+`.jpeg`、`.webp` 和静态 `.svg` 格式。真实设备效果图为必需项，项目 Logo
+为可选项。
 
 一句话总结：源码模式交源码给 Action 生成固件；仅固件模式直接提交可烧录文件。
 
@@ -94,7 +98,7 @@ cp -R integrations/_template integrations/my-firmware
 
 1. 修改目录名和 `integration.json.id`。
 2. 在项目 README 和 `integration.json` 中提供上游源码地址与许可证名称。
-3. 在 `assets/` 中加入 Logo 和真实设备效果图。
+3. 在 `assets/` 中加入真实设备效果图；项目需要 Logo 时一并加入。
 4. 选择源码模式时，加入 `source/`、`build` 配置和 `sourceBuild: true`。
 5. 选择仅固件包模式时，把经过测试的固件包放入 `firmware/<version>/`。
 6. 运行 Registry 测试和校验。
@@ -137,7 +141,6 @@ cp -R integrations/_template integrations/my-firmware
     "notes": "Tested on reTerminal Sticky production hardware."
   },
   "assets": {
-    "logo": "assets/logo.svg",
     "preview": "assets/preview.jpg",
     "previewAlt": "My Firmware running on reTerminal Sticky"
   },

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -97,13 +97,14 @@ cp -R integrations/_template integrations/my-firmware
 按下面的顺序准备：
 
 1. 修改目录名和 `integration.json.id`。
-2. 在项目 README 和 `integration.json` 中提供上游源码地址与许可证名称。
-3. 在 `assets/` 中加入真实设备效果图；项目需要 Logo 时一并加入。
-4. 选择源码模式时，加入 `source/`、`build` 配置和 `sourceBuild: true`。
-5. 选择仅固件包模式时，把经过测试的固件包放入 `firmware/<version>/`。
-6. 运行 Registry 测试和校验。
-7. 把这套固件烧录到真实 reTerminal Sticky 上测试。
-8. 提交 Pull Request，并写清测试结果。
+2. 填写必需的作者名称，并按需填写作者链接和展示来源。
+3. 在项目 README 和 `integration.json` 中提供上游源码地址与许可证名称。
+4. 在 `assets/` 中加入真实设备效果图；项目需要 Logo 时一并加入。
+5. 选择源码模式时，加入 `source/`、`build` 配置和 `sourceBuild: true`。
+6. 选择仅固件包模式时，把经过测试的固件包放入 `firmware/<version>/`。
+7. 运行 Registry 测试和校验。
+8. 把这套固件烧录到真实 reTerminal Sticky 上测试。
+9. 提交 Pull Request，并写清测试结果。
 
 一句话总结：准备项目资料和所选交付方式需要的文件后，再进入审核。
 
@@ -126,6 +127,10 @@ cp -R integrations/_template integrations/my-firmware
   "author": {
     "name": "Project author or team",
     "url": "https://github.com/example"
+  },
+  "origin": {
+    "name": "Project repository",
+    "url": "https://github.com/example/my-firmware"
   },
   "source": {
     "url": "https://github.com/example/my-firmware",
@@ -177,12 +182,19 @@ cp -R integrations/_template integrations/my-firmware
 | `catalogSection` | 固定为 `community` |
 | `mode` | 固定为 `flash` |
 | `status` | 按成熟度填写 `experimental`、`beta` 或 `stable` |
+| `author.name` | 必填，网站显示的作者或团队名称 |
+| `author.url` | 选填，点击作者名称时打开的 HTTPS 链接 |
+| `origin.name` | 选填，网站显示的来源名称 |
+| `origin.url` | 选填，点击来源名称时打开的 HTTPS 链接 |
 | `source.url` | 两种贡献方式都填写上游源码仓库地址 |
 | `source.license` | 源码许可证名称；仅固件包模式必须填写 |
 | `source.path` | 源码模式填写本地源码目录，通常为 `source` |
 | `build.*` | 源码模式与 `source.path` 一起提供的构建配置 |
 | `flash.versions[].sourceBuild` | 源码由 GitHub Actions 编译时设置为 `true` |
 | `flash.versions[].manifestPath` | 仅固件包模式填写项目内的 manifest 路径 |
+
+`author` 和 `origin` 用于网站署名展示；`source` 保存审核与固件打包使用的源码仓库、
+许可证和本地编译路径。
 
 `official` 和 `platform` 区域由 Seeed 或合作平台共同维护。普通外部 PR 统一进入
 `community` 区域。维护者可以把历史迁移但资料尚未齐全的条目标记为 `draft`；

--- a/integrations/_template/README.md
+++ b/integrations/_template/README.md
@@ -8,7 +8,8 @@ Copy this directory to `integrations/<integration-id>/`, then provide:
 3. For a firmware-only contribution, an upstream source URL and license plus
    the packaged files under `firmware/<version>/`.
 4. A real Sticky preview under `assets/`, plus an optional project logo when needed.
-5. The package origin, firmware behavior, and physical-device test result in
+5. The required author credit and optional display source in `integration.json`.
+6. The package origin, firmware behavior, and physical-device test result in
    this README.
 
 Run `npm test` and `npm run validate` from the repository root before opening a

--- a/integrations/_template/README.md
+++ b/integrations/_template/README.md
@@ -7,7 +7,7 @@ Copy this directory to `integrations/<integration-id>/`, then provide:
    builds and packages the firmware for this contribution mode.
 3. For a firmware-only contribution, an upstream source URL and license plus
    the packaged files under `firmware/<version>/`.
-4. A project logo and a real Sticky preview under `assets/`.
+4. A real Sticky preview under `assets/`, plus an optional project logo when needed.
 5. The package origin, firmware behavior, and physical-device test result in
    this README.
 

--- a/integrations/_template/assets/README.md
+++ b/integrations/_template/assets/README.md
@@ -1,7 +1,6 @@
 # Integration assets
 
-Replace this file with the integration's approved logo and preview image.
+Add the real Sticky preview image referenced by `assets.preview`.
 
-The paths and filenames must match the `assets.logo` and `assets.preview`
-values in the copied `integration.json`.
-
+Asset images may use PNG, JPG/JPEG, WebP, or static SVG files. An optional
+project logo may be added with `assets.logo` when the integration needs one.

--- a/integrations/_template/integration.json
+++ b/integrations/_template/integration.json
@@ -28,7 +28,6 @@
     "notes": "Describe the tested hardware revision or any required accessory."
   },
   "assets": {
-    "logo": "assets/logo.svg",
     "preview": "assets/preview.webp",
     "previewAlt": "Example Platform running on reTerminal Sticky"
   },

--- a/integrations/_template/integration.json
+++ b/integrations/_template/integration.json
@@ -12,6 +12,10 @@
     "name": "Project author or team",
     "url": "https://github.com/example"
   },
+  "origin": {
+    "name": "Project repository",
+    "url": "https://github.com/example/example-platform"
+  },
   "source": {
     "url": "https://github.com/example/example-platform",
     "license": "MIT",

--- a/integrations/sticky-2048/integration.json
+++ b/integrations/sticky-2048/integration.json
@@ -12,6 +12,10 @@
     "name": "Lukilyy",
     "url": "https://github.com/Lukilyy"
   },
+  "origin": {
+    "name": "Sticky 2048 project",
+    "url": "https://github.com/Lukilyy/reterminal-sticky-2048-eink-game"
+  },
   "source": {
     "url": "https://github.com/Lukilyy/reterminal-sticky-2048-eink-game",
     "license": "MIT",

--- a/schemas/integration.schema.json
+++ b/schemas/integration.schema.json
@@ -83,6 +83,9 @@
     "author": {
       "$ref": "#/$defs/attribution"
     },
+    "origin": {
+      "$ref": "#/$defs/attribution"
+    },
     "source": {
       "type": "object",
       "additionalProperties": false,
@@ -473,8 +476,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "name",
-        "url"
+        "name"
       ],
       "properties": {
         "name": {

--- a/schemas/integration.schema.json
+++ b/schemas/integration.schema.json
@@ -144,7 +144,6 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "logo",
         "preview",
         "previewAlt"
       ],

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -41,6 +41,7 @@ const COMMON_FIELDS = new Set([
   'summary',
   'description',
   'author',
+  'origin',
   'source',
   'support',
   'documentationUrl',
@@ -136,12 +137,14 @@ function validateOptionalBoolean(value, scope) {
 
 function validateAttribution(value, scope) {
   const allowedKeys = new Set(['name', 'url']);
-  if (!validateObjectKeys(value, ['name', 'url'], allowedKeys, scope)) {
+  if (!validateObjectKeys(value, ['name'], allowedKeys, scope)) {
     return;
   }
 
   validateString(value.name, `${scope}.name`, { max: 80 });
-  validateHttpsUrl(value.url, `${scope}.url`);
+  if (value.url !== undefined) {
+    validateHttpsUrl(value.url, `${scope}.url`);
+  }
 }
 
 function validateSource(value, scope) {
@@ -698,6 +701,9 @@ function validateIntegration(integrationDir, directoryName, seenIds) {
   validateString(integration.summary, `${scope}.summary`, { max: 140 });
   validateString(integration.description, `${scope}.description`, { max: 800 });
   validateAttribution(integration.author, `${scope}.author`);
+  if (integration.origin !== undefined) {
+    validateAttribution(integration.origin, `${scope}.origin`);
+  }
   validateSource(integration.source, `${scope}.source`);
   if (integration.source?.path !== undefined) {
     validateLocalDirectoryPath(integration.source.path, integrationDir, `${scope}.source.path`);

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -349,19 +349,21 @@ function validateAssetContent(filePath, scope) {
 
 function validateAssets(value, integrationDir, scope) {
   const allowedKeys = new Set(['logo', 'preview', 'previewAlt']);
-  if (!validateObjectKeys(value, ['logo', 'preview', 'previewAlt'], allowedKeys, scope)) {
+  if (!validateObjectKeys(value, ['preview', 'previewAlt'], allowedKeys, scope)) {
     return;
   }
 
-  const logoPath = validateLocalFilePath(value.logo, integrationDir, `${scope}.logo`, {
-    extensions: ALLOWED_ASSET_EXTENSIONS,
-    maxBytes: 1024 * 1024,
-  });
+  if (value.logo !== undefined) {
+    const logoPath = validateLocalFilePath(value.logo, integrationDir, `${scope}.logo`, {
+      extensions: ALLOWED_ASSET_EXTENSIONS,
+      maxBytes: 1024 * 1024,
+    });
+    validateAssetContent(logoPath, `${scope}.logo`);
+  }
   const previewPath = validateLocalFilePath(value.preview, integrationDir, `${scope}.preview`, {
     extensions: ALLOWED_ASSET_EXTENSIONS,
     maxBytes: 5 * 1024 * 1024,
   });
-  validateAssetContent(logoPath, `${scope}.logo`);
   validateAssetContent(previewPath, `${scope}.preview`);
   validateString(value.previewAlt, `${scope}.previewAlt`, { max: 180 });
 }

--- a/scripts/validate-registry.test.mjs
+++ b/scripts/validate-registry.test.mjs
@@ -124,6 +124,45 @@ test('accepts an integration without an optional logo', () => {
   assert.match(result.stdout, /Registry validation passed \(1 integration\(s\)\)\./);
 });
 
+test('accepts plain-text author and optional source attribution', () => {
+  const root = createRegistry();
+  const integration = validBase('plain-attribution', 'external');
+  delete integration.author.url;
+  integration.origin = {
+    name: 'Example Community',
+  };
+  integration.external = {
+    label: 'Open official tool',
+    url: 'https://example.com/tool',
+    description: 'Continue in the maintained upstream tool.',
+  };
+  writeIntegration(root, integration);
+
+  const result = runValidator(root);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Registry validation passed \(1 integration\(s\)\)\./);
+});
+
+test('rejects source attribution without a name', () => {
+  const root = createRegistry();
+  const integration = validBase('unnamed-origin', 'external');
+  integration.origin = {
+    url: 'https://example.com/community',
+  };
+  integration.external = {
+    label: 'Open official tool',
+    url: 'https://example.com/tool',
+    description: 'Continue in the maintained upstream tool.',
+  };
+  writeIntegration(root, integration);
+
+  const result = runValidator(root);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /origin: missing required field "name"/);
+});
+
 test('accepts a valid external integration', () => {
   const root = createRegistry();
   const integration = validBase('external-platform', 'external');

--- a/scripts/validate-registry.test.mjs
+++ b/scripts/validate-registry.test.mjs
@@ -107,6 +107,23 @@ test('accepts an empty production registry', () => {
   assert.match(result.stdout, /Registry validation passed \(0 integration\(s\)\)\./);
 });
 
+test('accepts an integration without an optional logo', () => {
+  const root = createRegistry();
+  const integration = validBase('preview-only', 'external');
+  delete integration.assets.logo;
+  integration.external = {
+    label: 'Open official tool',
+    url: 'https://example.com/tool',
+    description: 'Continue in the maintained upstream tool.',
+  };
+  writeIntegration(root, integration);
+
+  const result = runValidator(root);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Registry validation passed \(1 integration\(s\)\)\./);
+});
+
 test('accepts a valid external integration', () => {
   const root = createRegistry();
   const integration = validBase('external-platform', 'external');


### PR DESCRIPTION
## Summary

- Make project logos optional while keeping the real device preview required.
- Add required author attribution and optional display source attribution.
- Support optional HTTPS links for author and source labels.
- Update the integration template, schema, validator, PR checklist, and bilingual contribution guides.
- Add Sticky 2048 attribution metadata.

## Why

Community firmware cards and flash pages should credit their authors and optionally show where a project came from while preserving the existing technical source and license checks.

## Validation

- `npm test` (20 tests passed)
- `npm run validate` (3 integrations passed)
