### PR TITLE
feat: add reTerminal Sticky official firmware v1.1.0

### DIFF
--- a/integrations/sticky-factory/firmware/1.1.0/manifest.json
+++ b/integrations/sticky-factory/firmware/1.1.0/manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "reTerminal Sticky Official Firmware",
+  "version": "1.1.0",
+  "flashSize": "32MB",
+  "flashMode": "dio",
+  "flashFreq": "80m",
+  "baudRate": 460800,
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        {
+          "path": "reterminal_sticky_1_1_0.bin",
+          "offset": 0,
+          "size": 33292288,
+          "sha256": "8b149c809b7c07c680a59ab5621d7bd29ca85a8c1c9e9060b0040b387b4517e4",
+          "md5": "ceb396cfd9c3a6fc0d07c81e08194d1d"
+        }
+      ]
+    }
+  ]
+}

--- a/integrations/sticky-factory/integration.json
+++ b/integrations/sticky-factory/integration.json
@@ -38,6 +38,11 @@
   "flash": {
     "versions": [
       {
+        "version": "1.1.0",
+        "channel": "stable",
+        "manifestPath": "firmware/1.1.0/manifest.json"
+      },
+      {
         "version": "1.0.1",
         "channel": "stable",
         "manifestUrl": "https://github.com/Seeed-Projects/reterminal-sticky-playground-registry/releases/download/sticky-official-v1.0.1/manifest.json",


### PR DESCRIPTION
## Summary

Add reTerminal Sticky Official Firmware v1.1.0 as a verified firmware-only package.

## Package

- Version: `1.1.0`
- Device: reTerminal Sticky
- Chip: ESP32-S3
- Package type: merged firmware binary
- Flash offset: `0x0`
- Binary size: `33,292,288` bytes
- SHA-256: `8b149c809b7c07c680a59ab5621d7bd29ca85a8c1c9e9060b0040b387b4517e4`

## Validation

- `npm test`: 23 tests passed
- `npm run validate`: Registry validation passed
- Physical-device flash erase completed successfully
- Firmware was written from offset `0x0`
- esptool verified the written data hash
- Device boot and firmware operation verified

## Release

After review, the firmware package can be published as:

- Tag: `sticky-official-v1.1.0`
- Title: `reTerminal Sticky Official Firmware 1.1.0`