### PR TITLE
feat: archive Sticky official firmware 1.1.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,14 +3,17 @@
 - Platform or project name:
 - Integration ID:
 - Firmware version:
+- Firmware artifact origin:
+- Firmware artifact SHA-256:
 - Upstream project:
-- Source license:
+- Source license (community or partner firmware-only contributions):
 
 ### Contribution type
 
 - [ ] New community integration
 - [ ] New partner integration coordinated with the platform owner
-- [ ] Existing integration update
+- [ ] Official Sticky firmware update maintained by Seeed
+- [ ] Existing community or partner integration update
 
 ### Package type
 
@@ -50,7 +53,8 @@ Complete this section when **Source contribution built by GitHub Actions** is se
 Complete this section when **Firmware-only package** is selected.
 
 - [ ] Not applicable because **Source contribution built by GitHub Actions** is selected.
-- [ ] `source.url` points to the upstream source and `source.license` identifies its license.
+- [ ] `source.url` points to the maintained upstream project.
+- [ ] Community and partner packages identify their source license; official updates identify the official artifact origin in the dedicated section.
 - [ ] The README identifies the exact package origin, firmware version, and tested hardware.
 - [ ] Every required `.bin` file is committed under `firmware/<version>/`.
 - [ ] The local manifest records every firmware file, flash offset, byte size, and SHA-256.
@@ -59,7 +63,7 @@ Complete this section when **Firmware-only package** is selected.
 
 Complete this section when **New community integration** is selected.
 
-- [ ] Not applicable because **Existing integration update** is selected.
+- [ ] Not applicable because a new partner, official firmware, or existing integration update is selected.
 - [ ] `integration.json` uses `"group": "community"`, `"catalogSection": "community"`, and `"mode": "flash"`.
 - [ ] The project metadata, assets, compatibility, installation notes, and support links are complete.
 
@@ -67,16 +71,28 @@ Complete this section when **New community integration** is selected.
 
 Complete this section when **New partner integration coordinated with the platform owner** is selected.
 
-- [ ] Not applicable because this is a community integration or an existing integration update.
+- [ ] Not applicable because this is a community, official firmware, or existing integration update.
 - [ ] `integration.json` uses `"group": "partner"`, `"catalogSection": "platform"`, and `"mode": "flash"`.
 - [ ] Project, source, documentation, and support links point to official platform resources.
 - [ ] The platform metadata, official logo, compatibility, installation notes, and firmware package are complete.
 
-## Existing integration update verification
+## Official Sticky firmware update verification
 
-Complete this section when **Existing integration update** is selected.
+Complete this section when **Official Sticky firmware update maintained by Seeed** is selected.
 
-- [ ] Not applicable because **New community integration** is selected.
+- [ ] Not applicable because this is a community or partner contribution.
+- [ ] `sticky-factory` retains `"group": "official"`, `"catalogSection": "official"`, and `"mode": "flash"`.
+- [ ] The newest version appears first and uses `firmware/<version>/manifest.json` through `manifestPath`.
+- [ ] The version directory contains the complete official binary package used for physical-device testing.
+- [ ] The README and pull request record the official artifact origin, byte size, SHA-256, device, chip, and flash offset.
+- [ ] Existing Release-backed versions remain available through their current `manifestUrl`, `manifestSha256`, and `releaseUrl` records.
+- [ ] The committed version directory is the delivery record for the new official version.
+
+## Existing community or partner integration update verification
+
+Complete this section when **Existing community or partner integration update** is selected.
+
+- [ ] Not applicable because a new community, new partner, or official firmware contribution is selected.
 - [ ] The existing `group`, `catalogSection`, and `mode` are retained unless this PR intentionally changes them.
 - [ ] The newest firmware version appears first in `flash.versions`.
 - [ ] Every older version still referenced by `integration.json` remains available.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,6 +234,30 @@ result in the integration README and pull request.
 }
 ```
 
+## Official Sticky firmware updates
+
+Seeed-maintained updates to `sticky-factory` use the firmware-only package path
+with `"group": "official"`, `"catalogSection": "official"`, and
+`"mode": "flash"`. Add each new official version under
+`integrations/sticky-factory/firmware/<version>/` and set the newest
+`flash.versions` entry to the exact local path
+`firmware/<version>/manifest.json`.
+
+The version directory contains the complete tested binary package. Its manifest
+records the firmware version, chip family, flash settings, part offsets, byte
+sizes, SHA-256 values, and optional MD5 values. The integration README and pull
+request record the official artifact origin and the same package metadata.
+
+Official versions that already use Registry GitHub Releases keep their existing
+`manifestUrl`, `manifestSha256`, and `releaseUrl` records. This allows the newest
+version to use repository-backed storage while preserving every historical
+download. The committed version directory is the single delivery record for a
+new repository-backed official version.
+
+Select **Official Sticky firmware update maintained by Seeed** in the pull
+request template and complete its package, provenance, and physical-device
+verification fields.
+
 ## Source contribution requirements
 
 For the source path, the `source/` directory must build independently
@@ -299,6 +323,7 @@ The validator checks:
 - firmware file existence, byte size, and SHA-256;
 - non-overlapping flash address ranges;
 - the direct-flash requirements for community catalog entries.
+- the repository-backed package path for the newest Sticky official firmware.
 
 For source contributions, manifest and firmware-file checks run after GitHub
 Actions builds the project. For firmware-only contributions, they run directly
@@ -362,8 +387,9 @@ For a new version:
 ## Pull request checklist
 
 - [ ] One integration directory contains the complete contribution.
-- [ ] `integration.json` uses `community` + `community` + `flash`.
-- [ ] The contribution uses either source plus build metadata, or firmware-only plus an upstream source URL and license.
+- [ ] `integration.json` uses the group, catalog section, and mode documented for the selected contribution type.
+- [ ] The contribution uses either source plus build metadata, or firmware-only plus the provenance required for its contribution type.
+- [ ] Official firmware updates use the repository-backed version directory and record the official artifact origin.
 - [ ] The source path uses `sourceBuild: true`, or the firmware-only path includes the manifest and every required `.bin`.
 - [ ] The README and PR identify the tested package origin and firmware version.
 - [ ] `npm test` and `npm run validate` pass.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -231,6 +231,28 @@ Release，供 Sticky 测试分支读取。
 
 一句话总结：提交源码时由 Action 产出固件；直接提交固件时由作者提供完整烧录包。
 
+## Sticky 官方固件更新
+
+由 Seeed 维护的 `sticky-factory` 更新使用仅固件包方式，并保持
+`"group": "official"`、`"catalogSection": "official"` 和
+`"mode": "flash"`。每个新官方版本存放在
+`integrations/sticky-factory/firmware/<version>/`，同时把
+`flash.versions` 中的最新版本指向准确的本地路径
+`firmware/<version>/manifest.json`。
+
+版本目录保存经过测试的完整固件包。manifest 记录固件版本、芯片型号、烧录参数、
+分区地址、字节大小、SHA-256，以及可选的 MD5。集成 README 和 PR 同步记录官方固件
+产物来源及相同的包信息。
+
+已经使用 Registry GitHub Release 的官方历史版本继续保留原有 `manifestUrl`、
+`manifestSha256` 和 `releaseUrl`。这样，新版本使用仓库内存档，所有历史下载仍然保持
+原来的固定地址。新官方版本提交后，其版本目录就是该版本唯一的交付记录。
+
+提交时在 PR 模板中选择 **Official Sticky firmware update maintained by Seeed**，并完整
+填写固件包来源和实机测试结果。
+
+一句话总结：新官方固件进入版本目录，现有历史版本继续从原来的 Release 提供。
+
 ## 源码模式要求
 
 源码模式的 `source/` 必须能够仅依靠本次提交的文件完成编译。它应包含工程构建
@@ -295,6 +317,7 @@ npm run validate
 - 每个已提交固件文件存在，大小和 SHA-256 一致；
 - 不同固件分区的烧录地址没有重叠；
 - 社区条目满足本站直接烧录的全部要求。
+- Sticky 最新官方固件使用仓库内的标准版本目录。
 
 一句话总结：这一步负责提前发现“少文件、固件不匹配、烧录地址错误”等问题。
 
@@ -363,8 +386,9 @@ Sticky 网站仓库闭源。
 ## PR 提交前清单
 
 - [ ] 一个项目目录包含本次完整贡献。
-- [ ] `integration.json` 使用 `community` + `community` + `flash`。
-- [ ] 已选择“源码 + 构建配置”或“仅固件包 + 上游源码地址与许可证”。
+- [ ] `integration.json` 使用所选贡献类型规定的分组、目录区域和模式。
+- [ ] 已选择“源码 + 构建配置”或“仅固件包 + 对应贡献类型要求的产物来源信息”。
+- [ ] 官方固件更新使用仓库内版本目录，并记录官方固件产物来源。
 - [ ] 源码模式使用 `sourceBuild: true`，或仅固件包模式包含 manifest 和全部必需 `.bin`。
 - [ ] README 和 PR 写明经过测试的固件来源和固件版本。
 - [ ] `npm test` 和 `npm run validate` 全部通过。

--- a/integrations/sticky-factory/README.md
+++ b/integrations/sticky-factory/README.md
@@ -3,5 +3,21 @@
 This entry provides versioned official firmware packages for browser-based
 installation and factory recovery in the reTerminal Sticky Playground.
 
-The firmware files are published as Registry GitHub Release assets. Each
-version records the exact manifest SHA-256 used by the Sticky website build.
+New official firmware versions are archived under `firmware/<version>/` with a
+local manifest and the complete installable binary. The Registry validator
+checks the recorded byte size and SHA-256 before the package is accepted.
+
+Official versions published before repository-backed archiving remain available
+through their existing Registry GitHub Releases. `integration.json` preserves
+the delivery method associated with each version.
+
+## Repository-backed versions
+
+### 1.1.0
+
+- Device: reTerminal Sticky
+- Chip: ESP32-S3
+- Package: merged official firmware binary
+- Flash offset: `0x0`
+- Binary size: `33,292,288` bytes
+- SHA-256: `8b149c809b7c07c680a59ab5621d7bd29ca85a8c1c9e9060b0040b387b4517e4`

--- a/integrations/sticky-factory/firmware/1.1.0/manifest.json
+++ b/integrations/sticky-factory/firmware/1.1.0/manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "reTerminal Sticky Official Firmware",
+  "version": "1.1.0",
+  "flashSize": "32MB",
+  "flashMode": "dio",
+  "flashFreq": "80m",
+  "baudRate": 460800,
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        {
+          "path": "reterminal_sticky_1_1_0.bin",
+          "offset": 0,
+          "size": 33292288,
+          "sha256": "8b149c809b7c07c680a59ab5621d7bd29ca85a8c1c9e9060b0040b387b4517e4",
+          "md5": "ceb396cfd9c3a6fc0d07c81e08194d1d"
+        }
+      ]
+    }
+  ]
+}

--- a/integrations/sticky-factory/integration.json
+++ b/integrations/sticky-factory/integration.json
@@ -38,6 +38,11 @@
   "flash": {
     "versions": [
       {
+        "version": "1.1.0",
+        "channel": "stable",
+        "manifestPath": "firmware/1.1.0/manifest.json"
+      },
+      {
         "version": "1.0.1",
         "channel": "stable",
         "manifestUrl": "https://github.com/Seeed-Projects/reterminal-sticky-playground-registry/releases/download/sticky-official-v1.0.1/manifest.json",

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -246,6 +246,36 @@ function validateDirectFlashPackage(integration, integrationDir, scope) {
   }
 }
 
+// Validates the repository-backed package contract for Sticky official firmware.
+// 校验 Sticky 官方固件在仓库内归档时使用的包规则。
+function validateStickyOfficialFirmwarePackage(integration, integrationDir, scope) {
+  validatePackagedProjectFiles(integrationDir, undefined, scope);
+
+  if (integration.group !== 'official') {
+    addError(`${scope}.group`, 'must be "official" for Sticky official firmware');
+  }
+  if (integration.catalogSection !== 'official') {
+    addError(`${scope}.catalogSection`, 'must be "official" for Sticky official firmware');
+  }
+  if (integration.mode !== 'flash') {
+    addError(`${scope}.mode`, 'must be "flash" for Sticky official firmware');
+    return;
+  }
+
+  const latestVersion = integration.flash?.versions?.[0];
+  if (!latestVersion || typeof latestVersion.version !== 'string') {
+    return;
+  }
+
+  const expectedManifestPath = `firmware/${latestVersion.version}/manifest.json`;
+  if (latestVersion.manifestPath !== expectedManifestPath) {
+    addError(
+      `${scope}.flash.versions[0].manifestPath`,
+      `must be "${expectedManifestPath}" for the newest Sticky official firmware`,
+    );
+  }
+}
+
 function validateSupport(value, scope) {
   const allowedKeys = new Set(['url']);
   if (!validateObjectKeys(value, ['url'], allowedKeys, scope)) {
@@ -796,6 +826,10 @@ function validateIntegration(integrationDir, directoryName, seenIds) {
       addError(`${scope}.mode`, 'must be "flash" for partner integrations');
     }
     validateDirectFlashPackage(integration, integrationDir, scope);
+  }
+
+  if (integration.id === 'sticky-factory') {
+    validateStickyOfficialFirmwarePackage(integration, integrationDir, scope);
   }
 
   for (const modeField of MODE_FIELDS) {

--- a/scripts/validate-registry.test.mjs
+++ b/scripts/validate-registry.test.mjs
@@ -196,6 +196,79 @@ test('accepts a firmware-only partner integration without author attribution', (
   assert.equal(result.status, 0, result.stderr);
 });
 
+test('accepts repository-backed Sticky official firmware with Release-backed history', () => {
+  const root = createRegistry();
+  const integration = validBase('sticky-factory', 'flash');
+  integration.group = 'official';
+  integration.catalogSection = 'official';
+  delete integration.source.license;
+  integration.flash = {
+    versions: [
+      {
+        version: '1.1.0',
+        channel: 'stable',
+        manifestPath: 'firmware/1.1.0/manifest.json',
+      },
+      {
+        version: '1.0.1',
+        channel: 'stable',
+        manifestUrl: 'https://github.com/example/registry/releases/download/v1.0.1/manifest.json',
+        manifestSha256: 'a'.repeat(64),
+        releaseUrl: 'https://github.com/example/registry/releases/tag/v1.0.1',
+      },
+    ],
+  };
+  const integrationDir = writeIntegration(root, integration);
+  writeFileSync(join(integrationDir, 'README.md'), '# Sticky Official Firmware\n');
+  mkdirSync(join(integrationDir, 'firmware', '1.1.0'), { recursive: true });
+  const binary = Buffer.from([0xe9, 0x01, 0x02, 0x03]);
+  const sha256 = createHash('sha256').update(binary).digest('hex');
+  writeFileSync(join(integrationDir, 'firmware', '1.1.0', 'firmware.bin'), binary);
+  writeFileSync(
+    join(integrationDir, 'firmware', '1.1.0', 'manifest.json'),
+    `${JSON.stringify({
+      name: 'Sticky Official Firmware',
+      version: '1.1.0',
+      flashSize: '32MB',
+      builds: [{
+        chipFamily: 'ESP32-S3',
+        parts: [{ path: 'firmware.bin', offset: 0, size: binary.length, sha256 }],
+      }],
+    }, null, 2)}\n`,
+  );
+
+  const result = runValidator(root);
+
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('requires the newest Sticky official firmware to use its version directory', () => {
+  const root = createRegistry();
+  const integration = validBase('sticky-factory', 'flash');
+  integration.group = 'official';
+  integration.catalogSection = 'official';
+  delete integration.source.license;
+  integration.flash = {
+    versions: [{
+      version: '1.1.0',
+      channel: 'stable',
+      manifestUrl: 'https://github.com/example/registry/releases/download/v1.1.0/manifest.json',
+      manifestSha256: 'b'.repeat(64),
+      releaseUrl: 'https://github.com/example/registry/releases/tag/v1.1.0',
+    }],
+  };
+  const integrationDir = writeIntegration(root, integration);
+  writeFileSync(join(integrationDir, 'README.md'), '# Sticky Official Firmware\n');
+
+  const result = runValidator(root);
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /must be "firmware\/1\.1\.0\/manifest\.json" for the newest Sticky official firmware/,
+  );
+});
+
 test('requires author attribution for community integrations', () => {
   const root = createRegistry();
   const integration = validBase('community-without-author', 'external');


### PR DESCRIPTION
## Contribution

- Platform or project name: reTerminal Sticky Official Firmware
- Integration ID: `sticky-factory`
- Firmware version: `1.1.0`
- Firmware artifact origin: Official Seeed Studio firmware binary supplied for Registry archival
- Firmware artifact SHA-256: `8b149c809b7c07c680a59ab5621d7bd29ca85a8c1c9e9060b0040b387b4517e4`
- Upstream project: https://github.com/Seeed-Projects/OSHW-reTerminal-Sticky
- Source license: Not applicable to this official binary package

### Contribution type

- [ ] New community integration
- [ ] New partner integration coordinated with the platform owner
- [x] Official Sticky firmware update maintained by Seeed
- [ ] Existing community or partner integration update

### Package type

- [ ] Source contribution built by GitHub Actions
- [x] Firmware-only package

## What this contribution provides

Archives reTerminal Sticky Official Firmware `1.1.0` directly in the Registry and makes it the newest browser-installable official version. Existing official versions keep their current immutable GitHub Release records.

This pull request also documents and enforces the official firmware update path so future releases use `integrations/sticky-factory/firmware/<version>/` consistently.

## Common verification

- [x] `npm test` passes locally: 25/25 tests.
- [x] `npm run validate` passes locally: 6 integrations.
- [x] The integration directory and `id` use the same lowercase kebab-case name.
- [x] The integration README identifies the package origin and firmware version.
- [x] Existing official project, support, and documentation links remain current in the integration metadata.
- [x] Existing official artwork is retained.
- [x] The submitted files contain no user-specific credentials, API keys, tokens, passwords, or private keys.
- [x] The selected package type has all required firmware files.

## Source contribution verification

- [x] Not applicable because **Firmware-only package** is selected.

## Firmware-only verification

- [x] `source.url` points to the maintained upstream project.
- [x] The official artifact origin is recorded in this pull request and the integration README.
- [x] Every required `.bin` file is committed under `firmware/1.1.0/`.
- [x] The local manifest records the firmware file, flash offset, byte size, SHA-256, and MD5.

## New community integration verification

- [x] Not applicable because an official firmware update is selected.

## New partner integration verification

- [x] Not applicable because an official firmware update is selected.

## Official Sticky firmware update verification

- [x] `sticky-factory` retains `"group": "official"`, `"catalogSection": "official"`, and `"mode": "flash"`.
- [x] Version `1.1.0` appears first and uses `firmware/1.1.0/manifest.json` through `manifestPath`.
- [x] The version directory contains the complete merged official binary package.
- [x] The README and pull request record the artifact origin, byte size, SHA-256, device, chip, and flash offset.
- [x] Existing Release-backed versions remain available through their current `manifestUrl`, `manifestSha256`, and `releaseUrl` records.
- [x] The committed version directory is the delivery record for official firmware `1.1.0`.

## Existing community or partner integration update verification

- [x] Not applicable because an official firmware update is selected.

## Physical-device test

- Device and hardware revision: Pending maintainer hardware acceptance
- Installation method: Browser flasher or `esptool` using the merged image at `0x0`
- Tested firmware version: `1.1.0`
- Main workflow tested: Pending maintainer hardware acceptance
- Reboot and saved-state result: Pending maintainer hardware acceptance
- USB reconnection and repeated-install result: Pending maintainer hardware acceptance

- [ ] The submitted firmware package was installed on a physical reTerminal Sticky during this contribution review.
- [ ] First boot and the main user workflow passed during this contribution review.
- [ ] Touch and hardware buttons passed during this contribution review.
- [ ] Reboot, saved state, USB reconnection, and repeated installation passed during this contribution review.

## Additional context

- Binary size: `33,292,288` bytes
- MD5: `ceb396cfd9c3a6fc0d07c81e08194d1d`
- Chip: ESP32-S3
- Flash size: 32 MB
- Flash mode: DIO
- Flash frequency: 80 MHz
- Flash offset: `0x0`
- `esptool image-info` recognized the image and reported a valid image checksum and validation hash.
- `git diff --check` passes.
- The Registry regression suite covers repository-backed current firmware with Release-backed history and rejects a Release-only newest official version.
