### PR TITLE
fix: register Sticky Lotus v1.1.0

### DIFF
--- a/integrations/sticky-lotus/integration.json
+++ b/integrations/sticky-lotus/integration.json
@@ -41,6 +41,11 @@
   "flash": {
     "versions": [
       {
+        "version": "1.1.0",
+        "channel": "stable",
+        "manifestPath": "firmware/1.1.0/manifest.json"
+      },
+      {
         "version": "1.0.0",
         "channel": "stable",
         "manifestPath": "firmware/1.0.0/manifest.json"


### PR DESCRIPTION
Register Sticky Lotus v1.1.0 in integration.json so the Playground can publish and flash the new firmware version.