### PR TITLE
Expand the contribution guides into step-by-step handbooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,83 +1,278 @@
 # Contributing to reTerminal Sticky Playground
 
-This repository is the public contribution and review layer for the reTerminal
-Sticky Playground. It accepts two kinds of contributions, each with its own
-directory, metadata file, and guide.
+This repository is the public contribution and review layer for the
+[reTerminal Sticky Playground](https://www.seeedstudio.com/sticky/playground/).
+Everything a visitor sees on the Playground **Firmware** and **3D Printables**
+pages comes from the files in this repository. You add or change a directory
+here, open a pull request, a maintainer reviews it, and the Sticky website picks
+up the change in its next release.
 
 For the Chinese version, see [CONTRIBUTING.zh-CN.md](CONTRIBUTING.zh-CN.md).
 
-## Choose your guide
+## Contents
 
-| I want to share… | Directory | Metadata file | Guide |
+1. [Choose your guide](#1-choose-your-guide)
+2. [What you need](#2-what-you-need)
+3. [Repository layout](#3-repository-layout)
+4. [How a contribution reaches the website](#4-how-a-contribution-reaches-the-website)
+5. [Three ways to submit](#5-three-ways-to-submit)
+6. [Shared rules for every contribution](#6-shared-rules-for-every-contribution)
+7. [Local checks](#7-local-checks)
+8. [Pull request review](#8-pull-request-review)
+9. [After your pull request is merged](#9-after-your-pull-request-is-merged)
+10. [Updating or removing a contribution](#10-updating-or-removing-a-contribution)
+11. [FAQ](#11-faq)
+
+## 1. Choose your guide
+
+There are two kinds of contributions. Each has its own directory, metadata
+file, template, and detailed guide.
+
+| I want to share… | Directory | Metadata file | Template to copy | Detailed guide |
+|---|---|---|---|---|
+| Firmware that users flash from the Sticky website | `firmwares/<firmware-id>/` | `firmware.json` | `firmwares/_template/` | [Contributing firmware](docs/contributing-firmware.md) |
+| A 3D printable case, stand, mount, or accessory | `printables/<design-id>/` | `printable.json` | `printables/_template/` | [Contributing a 3D printable design](docs/contributing-printables.md) |
+
+- A **firmware** contribution ships either buildable ESP-IDF source that GitHub
+  Actions compiles, or a verified `.bin` package with a manifest. It needs a
+  physical-device test before review. Expect to spend an hour or two on the
+  first submission.
+- A **printable** contribution is a card: one JSON file, one photo, one short
+  README. The model files stay on your Printables / MakerWorld / Thingiverse /
+  GrabCAD / GitHub page. Expect 15–30 minutes.
+
+This page covers everything the two kinds have in common. Read it once, then
+follow the detailed guide for your content type.
+
+## 2. What you need
+
+| Requirement | Firmware | Printable | Notes |
 |---|---|---|---|
-| Firmware that users flash from the Sticky website | `firmwares/<firmware-id>/` | `firmware.json` | [Contributing firmware](docs/contributing-firmware.md) |
-| A 3D printable case, stand, mount, or accessory | `printables/<design-id>/` | `printable.json` | [Contributing a 3D printable design](docs/contributing-printables.md) |
+| A GitHub account | Yes | Yes | Free account is enough |
+| Git on your computer | Recommended | Optional | Printables can be submitted entirely in the GitHub web interface (see [Method B](#method-b-github-web-interface-no-git)) |
+| Node.js 20 or newer | Recommended | Optional | Runs the same checks locally that GitHub Actions runs on your PR |
+| A reTerminal Sticky | Yes | Yes | Firmware must be flashed and tested on a real device; printables need a photo of the print on a real device |
+| ESP-IDF | Optional | No | Only if you want to build firmware locally before submitting |
 
-Firmware contributions include buildable source or a verified firmware package,
-and are tested on a physical device before review. Printable contributions are
-a card with a preview photo; the model files stay on the author's download page.
-
-## Repository layout
+## 3. Repository layout
 
 ```text
-firmwares/
-  _template/                 copy this for a new firmware
+firmwares/                     one directory per firmware
+  _template/                   copy this to start a firmware
   <firmware-id>/
-    firmware.json
-    README.md
+    firmware.json              card text, links, build settings, versions
+    README.md                  behavior, controls, setup, device test record
     assets/
-    source/                  source contributions
-    firmware/<version>/      firmware-only contributions
-printables/
-  _template/                 copy this for a new printable design
+      preview.jpg              real Sticky screenshot or photo
+      logo.svg                 optional identity image
+    source/                    source contributions: the ESP-IDF project
+    firmware/<version>/        firmware-only contributions: manifest.json + *.bin
+
+printables/                    one directory per printable design
+  _template/                   copy this to start a design
   <design-id>/
-    printable.json
-    README.md
-    assets/preview.jpg
+    printable.json             card text, author, category, download page
+    README.md                  print settings and assembly notes
+    assets/
+      preview.jpg              photo of the print fitted on Sticky
+
 schemas/
-  firmware.schema.json
-  printable.schema.json
+  firmware.schema.json         formal definition of firmware.json
+  printable.schema.json        formal definition of printable.json
+
 scripts/
-  validate-registry.mjs      checks both directories
+  validate-registry.mjs        checks every directory; run with npm run validate
+  list-build-targets.mjs       finds source-built firmware for GitHub Actions
+  package-esp-idf.mjs          turns an ESP-IDF build into manifest.json + .bin
+
+docs/
+  contributing-firmware.md     detailed firmware guide (+ .zh-CN.md)
+  contributing-printables.md   detailed printables guide (+ .zh-CN.md)
+
+.github/
+  workflows/validate-registry.yml   runs on every PR and on main
+  pull_request_template.md          the checklist you fill in
 ```
 
-## Shared rules
+The directory name is the public identifier of your contribution. It appears
+in the website URL for firmware (`/sticky/playground/<firmware-id>/`) and in
+analytics for both kinds. Choose it carefully; renaming later is a new PR.
 
-- One directory per contribution. The directory name and the `id` inside the
-  metadata file are the same lowercase kebab-case identifier.
-- All links use HTTPS.
-- Images live under `assets/` and use PNG, JPG, WebP, or (firmware only) static SVG.
-- Submitted files contain no personal Wi-Fi credentials, API keys, tokens, or passwords.
-- Card text is written in English because the Sticky website serves a global audience.
+## 4. How a contribution reaches the website
 
-## Local checks
+```text
+1. You open a pull request that adds or changes one directory.
+2. GitHub Actions validates the repository and (for source firmware) compiles it.
+3. A maintainer reviews the PR and merges it into main.
+4. For source firmware, the main workflow publishes a GitHub Release with the .bin files.
+5. The Sticky website repository pins the new Registry commit.
+6. The website is built, tested locally and on a device, then deployed.
+7. Your card appears on https://www.seeedstudio.com/sticky/playground/.
+```
 
-Install Node.js 20 or newer, then run from the repository root:
+Steps 1–2 are yours. Steps 3–7 are done by maintainers; see
+[Section 9](#9-after-your-pull-request-is-merged) for what to expect.
+
+## 5. Three ways to submit
+
+Pick the one that matches your comfort with git. All three end with a pull
+request against `Seeed-Projects/reterminal-sticky-playground-registry:main`.
+
+### Method A: fork and clone with git (recommended for firmware)
+
+1. Fork the repository on GitHub: open
+   <https://github.com/Seeed-Projects/reterminal-sticky-playground-registry>
+   and select **Fork**.
+2. Clone your fork and create a branch:
+
+   ```bash
+   git clone https://github.com/<your-account>/reterminal-sticky-playground-registry.git
+   cd reterminal-sticky-playground-registry
+   git checkout -b add-my-design
+   ```
+
+3. Copy the template for your content type and fill it in (details in the
+   guide for your type):
+
+   ```bash
+   cp -R printables/_template printables/my-design     # printable
+   cp -R firmwares/_template  firmwares/my-firmware    # firmware
+   ```
+
+4. Run the local checks:
+
+   ```bash
+   npm test
+   npm run validate
+   ```
+
+5. Commit and push:
+
+   ```bash
+   git add printables/my-design
+   git commit -m "feat: add My Design printable"
+   git push -u origin add-my-design
+   ```
+
+6. Open the pull request. GitHub shows a **Compare & pull request** button on
+   your fork; select it, make sure the base is
+   `Seeed-Projects/reterminal-sticky-playground-registry` / `main`, then fill in
+   the template that appears in the description box.
+
+### Method B: GitHub web interface (no git)
+
+Suitable for printables and for small firmware metadata fixes.
+
+1. Fork the repository (same as step A1).
+2. In your fork, open the `printables/` directory and select
+   **Add file → Create new file**.
+3. In the file name box type `my-design/printable.json`. Typing a `/` creates
+   the directory. Paste the contents of
+   [`printables/_template/printable.json`](printables/_template/printable.json)
+   and edit the values.
+4. Select **Commit changes…**, choose **Create a new branch**, name it
+   `add-my-design`, and commit.
+5. Still on that branch, open `printables/my-design/` and use
+   **Add file → Upload files** to upload your photo into an `assets/`
+   sub-directory: drag the file in, then edit the path shown above the upload
+   area so it reads `printables/my-design/assets/preview.jpg`. Commit.
+6. Repeat step 5 with **Create new file** for `printables/my-design/README.md`.
+7. GitHub now shows a banner offering to open a pull request from your branch.
+   Select it, confirm the base is the Seeed repository's `main`, and fill in the
+   template.
+
+GitHub Actions runs the same checks as `npm run validate`; if something is
+wrong, the PR shows a red cross and the log tells you which field to fix. Edit
+the file on your branch and the check re-runs automatically.
+
+### Method C: edit an existing file in the browser (updates only)
+
+To fix a typo, change a link, or add a version to a card that already exists:
+
+1. Open the file on GitHub (for example
+   `printables/sticky-wallet-case/printable.json`).
+2. Select the pencil icon (**Edit this file**). GitHub forks the repository for
+   you if needed.
+3. Make the change, select **Commit changes…**, and choose **Propose changes**.
+4. GitHub opens the pull request form; fill in the template.
+
+## 6. Shared rules for every contribution
+
+These are enforced by `npm run validate` and by review.
+
+| Rule | Details |
+|---|---|
+| One directory per contribution | Everything for one firmware or one design lives in its own directory. Do not touch other directories in the same PR. |
+| Directory name = `id` | Lowercase letters, digits, and single hyphens only: `^[a-z0-9]+(?:-[a-z0-9]+)*$`, 2–64 characters. Examples: `sticky-2048`, `wallet-case`. The `id` field inside the metadata file must be identical. |
+| HTTPS links only | Every URL field must start with `https://`. |
+| Images under `assets/` | Referenced as `assets/<file>`. Firmware accepts PNG, JPG, WebP, or static SVG; printables accept PNG, JPG, WebP. Maximum 5 MB for previews, 1 MB for logos. |
+| Real images | Previews are real screenshots or photos on a reTerminal Sticky. Renders and stock images are not accepted. |
+| English card text | `name`, `summary`, `description`, `alt` texts, and README are in English because the website serves a global audience. |
+| No secrets | Source, configuration, and README contain no Wi-Fi passwords, API keys, tokens, or private keys. Use placeholders and describe runtime setup instead. |
+| Your own work or clearly credited | `author` names the person or team who made it. When you submit someone else's open design or firmware, credit them in `author` and link the original in `download.url` / `source.url`. |
+| Metadata files are strict | Unknown fields cause validation to fail. Copy the template and change values rather than adding new keys. |
+
+## 7. Local checks
+
+Install [Node.js](https://nodejs.org/) 20 or newer, then run from the
+repository root:
 
 ```bash
-npm test
-npm run validate
+npm test          # unit tests for the validator itself
+npm run validate  # checks every directory under firmwares/ and printables/
 ```
 
-The validator checks every firmware and printable directory and prints
-`Registry validation passed (N firmware(s), M printable(s)).` when the
-repository is consistent. GitHub Actions runs the same commands on every pull
-request.
+Successful output:
 
-## Pull request review
+```text
+Registry validation passed (12 firmware(s), 5 printable(s)).
+```
 
-1. Open a pull request and select the contribution type in the template.
-2. GitHub Actions validates the Registry and, for source-built firmware,
-   compiles the project and attaches the firmware as a PR artifact.
-3. A maintainer reviews the metadata, assets, links, license, and (for
-   firmware) the physical-device test record.
-4. The pull request is merged once the checks pass and the review is complete.
+Failure output lists each problem with the exact file and field:
 
-## After your pull request is merged
+```text
+Registry validation failed with 2 error(s):
+- printables/my-design/printable.json.download.url: must use HTTPS
+- printables/my-design/printable.json.preview.image: references a missing file: assets/preview.jpg
+```
 
-Merging a Registry pull request does not publish to the production website by
-itself. The Sticky website pins one reviewed Registry commit. Maintainers
-follow this sequence:
+Read the part after the file name as a path into your JSON: `download.url`
+means the `url` key inside the `download` object. Fix the field, run the
+command again, repeat until it passes.
+
+What the validator checks, for both kinds:
+
+- the directory name matches `id`;
+- every required field is present and no unknown field exists;
+- strings stay within their length limits and enumerated fields use an allowed value;
+- URLs are HTTPS;
+- referenced images exist, use an allowed extension, contain real image data, and stay under the size limit;
+- `README.md` exists.
+
+Firmware adds checks for source trees, build settings, manifests, `.bin` sizes,
+SHA-256 values, and flash offsets; see the firmware guide.
+
+## 8. Pull request review
+
+1. Open the pull request and fill in the template. Select exactly one
+   **Contribution type**; only the matching section of the template needs to be
+   completed.
+2. GitHub Actions runs `npm test` and `npm run validate`. For source-built
+   firmware it also compiles the project and attaches the firmware as a PR
+   artifact. A red cross means something failed; open **Details** to read the
+   log.
+3. A maintainer reviews metadata, images, links, license, and (for firmware)
+   the physical-device test record. Review comments appear on the PR; reply or
+   push fixes to the same branch.
+4. When the checks are green and the review is complete, the maintainer merges.
+
+Typical turnaround is a few working days. If a PR has been quiet for more than
+two weeks, leave a comment on it.
+
+## 9. After your pull request is merged
+
+Merging does not publish immediately. The Sticky website reads one pinned
+Registry commit, so maintainers release in batches:
 
 1. Merge the Registry pull request.
 2. For source-built firmware, wait for the Registry `main` workflow to publish
@@ -88,10 +283,51 @@ follow this sequence:
 5. For firmware, flash it from the local page to a physical device.
 6. Merge into the Sticky website `main` and deploy.
 
-New cards appear on <https://www.seeedstudio.com/sticky/playground/> after step 6.
+Your card appears on <https://www.seeedstudio.com/sticky/playground/> after
+step 6. You will see the closed PR referenced in the website release notes when
+that happens.
 
-## Updating an existing contribution
+## 10. Updating or removing a contribution
 
-Edit the files in your directory and open a new pull request. Firmware updates
-add the new version first in `flash.versions`; see the firmware guide.
-Printable updates change the card text, photo, category, or download page.
+**Update.** Edit the files in your directory and open a new pull request using
+any method above. Select **Firmware: update to an existing firmware** or
+**3D printable design** in the template. Firmware updates add the new version
+first in `flash.versions`; the firmware guide has the details.
+
+**Remove.** Open a pull request that deletes the directory and explain why in
+the description. Maintainers may instead keep the directory and mark it as no
+longer maintained if users still depend on it.
+
+**Transfer.** If someone else takes over maintenance, open a PR that changes
+`author` and links, and mention the previous author in the description so they
+can confirm.
+
+## 11. FAQ
+
+**Can I submit more than one design or firmware in one PR?**
+Please open one PR per directory. It keeps review focused and lets each card be
+released independently.
+
+**My design is on several platforms. Which one goes in `download.url`?**
+Pick the page you maintain most actively. Mention the others in the README.
+
+**I found a design by someone else that fits Sticky well. Can I add it?**
+Yes, if its license allows redistribution of the link and credit. Put the
+original designer in `author`, link their page in `download.url`, and say in
+the PR that you are submitting on their behalf.
+
+**Do I have to run `npm run validate` locally?**
+No. GitHub Actions runs it on your PR. Running it locally just gives you the
+answer in seconds instead of minutes.
+
+**The validator says `contains unsupported field "..."`.**
+The metadata files only accept the fields listed in their guide. Remove the
+extra key, or check for a typo in a valid key.
+
+**How do I test firmware on my device before submitting?**
+Build locally with ESP-IDF and flash with `idf.py flash`, or use the PR
+artifact that GitHub Actions produces after you open the PR. The firmware guide
+describes both.
+
+**Who do I ask if something is unclear?**
+Open an issue in this repository, or ask in the pull request itself.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -1,78 +1,256 @@
 # 为 reTerminal Sticky Playground 贡献内容
 
-这个仓库是 reTerminal Sticky Playground 面向外部开发者和创客的公开贡献与审核入口。
-它接受两类贡献，各有独立的目录、元数据文件和指南。
+这个仓库是 [reTerminal Sticky Playground](https://www.seeedstudio.com/sticky/playground/)
+面向外部开发者和创客的公开贡献与审核入口。访客在 Playground 的 **Firmware** 和
+**3D Printables** 两个页面看到的所有内容，都来自这个仓库里的文件。你在这里新增或
+修改一个目录，提交 pull request，维护者审核合并，Sticky 网站在下一次发布时把它带上线。
 
 英文版请查看 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
-## 选择你的指南
+## 目录
 
-| 我想分享… | 目录 | 元数据文件 | 指南 |
+1. [选择你的指南](#1-选择你的指南)
+2. [需要准备什么](#2-需要准备什么)
+3. [仓库结构](#3-仓库结构)
+4. [一份贡献如何到达网站](#4-一份贡献如何到达网站)
+5. [三种提交方式](#5-三种提交方式)
+6. [所有贡献共同遵守的规则](#6-所有贡献共同遵守的规则)
+7. [本地自检](#7-本地自检)
+8. [PR 审核](#8-pr-审核)
+9. [PR 合并之后](#9-pr-合并之后)
+10. [更新或移除已有贡献](#10-更新或移除已有贡献)
+11. [常见问题](#11-常见问题)
+
+## 1. 选择你的指南
+
+贡献分两类，各有独立的目录、元数据文件、模板和详细指南。
+
+| 我想分享… | 目录 | 元数据文件 | 复制哪个模板 | 详细指南 |
+|---|---|---|---|---|
+| 用户可以在 Sticky 网站直接烧录的固件 | `firmwares/<firmware-id>/` | `firmware.json` | `firmwares/_template/` | [贡献固件](docs/contributing-firmware.zh-CN.md) |
+| 3D 打印的外壳、支架、安装件或配件 | `printables/<design-id>/` | `printable.json` | `printables/_template/` | [贡献 3D 打印设计](docs/contributing-printables.zh-CN.md) |
+
+- **固件**贡献需要提交可编译的 ESP-IDF 源码（由 GitHub Actions 编译），或者一个
+  带 manifest 的、经过验证的 `.bin` 固件包，并在真机上测试后才能审核。第一次提交
+  预计一到两小时。
+- **打印件**贡献只是一张卡片：一个 JSON 文件、一张照片、一份简短 README。模型文件
+  留在你自己的 Printables / MakerWorld / Thingiverse / GrabCAD / GitHub 页面。
+  预计 15–30 分钟。
+
+本页只讲两类贡献共同的部分。读完一遍，再去看你那一类的详细指南。
+
+一句话总结：做固件看固件指南，做外壳看打印指南，本页是两条路共用的入口。
+
+## 2. 需要准备什么
+
+| 条件 | 固件 | 打印件 | 说明 |
 |---|---|---|---|
-| 用户可以在 Sticky 网站直接烧录的固件 | `firmwares/<firmware-id>/` | `firmware.json` | [贡献固件](docs/contributing-firmware.zh-CN.md) |
-| 3D 打印的外壳、支架、安装件或配件 | `printables/<design-id>/` | `printable.json` | [贡献 3D 打印设计](docs/contributing-printables.zh-CN.md) |
+| GitHub 账号 | 需要 | 需要 | 免费账号即可 |
+| 电脑上安装 Git | 推荐 | 可选 | 打印件可以完全在 GitHub 网页里完成，见[方式 B](#方式-bgithub-网页操作不需要-git) |
+| Node.js 20 或更高 | 推荐 | 可选 | 用来在本地跑和 GitHub Actions 相同的检查 |
+| 一台 reTerminal Sticky | 需要 | 需要 | 固件必须在真机上烧录测试；打印件需要一张装在真机上的照片 |
+| ESP-IDF | 可选 | 不需要 | 只有想在提交前本地编译固件时才需要 |
 
-固件贡献包含可编译源码或经过验证的固件包，审核前需要在真机上测试。3D 打印贡献
-只是一张带预览照片的卡片；模型文件留在作者自己的下载页。
-
-一句话总结：做固件看固件指南，做外壳看打印指南，两条路互不干扰。
-
-## 仓库结构
+## 3. 仓库结构
 
 ```text
-firmwares/
-  _template/                 新固件从这里复制
+firmwares/                     每个固件一个目录
+  _template/                   新固件从这里复制
   <firmware-id>/
-    firmware.json
-    README.md
+    firmware.json              卡片文字、链接、编译设置、版本列表
+    README.md                  功能说明、操作方式、配置、真机测试记录
     assets/
-    source/                  源码模式
-    firmware/<version>/      仅固件包模式
-printables/
-  _template/                 新打印设计从这里复制
+      preview.jpg              真实的 Sticky 截图或照片
+      logo.svg                 可选的标识图
+    source/                    源码模式：ESP-IDF 工程
+    firmware/<version>/        仅固件包模式：manifest.json + *.bin
+
+printables/                    每个打印设计一个目录
+  _template/                   新设计从这里复制
   <design-id>/
-    printable.json
-    README.md
-    assets/preview.jpg
+    printable.json             卡片文字、作者、分类、下载页
+    README.md                  打印参数和组装说明
+    assets/
+      preview.jpg              打印成品装在 Sticky 上的照片
+
 schemas/
-  firmware.schema.json
-  printable.schema.json
+  firmware.schema.json         firmware.json 的正式定义
+  printable.schema.json        printable.json 的正式定义
+
 scripts/
-  validate-registry.mjs      同时检查两个目录
+  validate-registry.mjs        检查全部目录；通过 npm run validate 运行
+  list-build-targets.mjs       为 GitHub Actions 找出需要编译的源码固件
+  package-esp-idf.mjs          把 ESP-IDF 编译结果整理成 manifest.json + .bin
+
+docs/
+  contributing-firmware.md     固件详细指南（另有 .zh-CN.md）
+  contributing-printables.md   打印件详细指南（另有 .zh-CN.md）
+
+.github/
+  workflows/validate-registry.yml   每个 PR 和 main 分支都会运行
+  pull_request_template.md          你提交 PR 时要填写的清单
 ```
 
-## 共同规则
+目录名就是这份贡献的公开标识。固件的目录名会出现在网站地址里
+（`/sticky/playground/<firmware-id>/`），两类贡献的目录名都会出现在统计数据里。
+请认真取名，之后改名需要再提一个 PR。
 
-- 每份贡献一个目录。目录名与元数据文件里的 `id` 使用同一个小写连字符标识。
-- 所有链接使用 HTTPS。
-- 图片放在 `assets/` 下，使用 PNG、JPG、WebP，固件条目还可以使用静态 SVG。
-- 提交的文件中不包含个人 Wi-Fi 凭据、API key、token 或密码。
-- 卡片文字使用英文，因为 Sticky 网站面向全球访客。
+## 4. 一份贡献如何到达网站
 
-## 本地自检
+```text
+1. 你提交一个 pull request，新增或修改一个目录。
+2. GitHub Actions 校验仓库；源码模式固件还会被编译。
+3. 维护者审核 PR 并合并到 main。
+4. 源码模式固件：main 分支的工作流发布带 .bin 文件的 GitHub Release。
+5. Sticky 网站仓库锁定这个新的 Registry 提交。
+6. 网站构建、本地验证、真机验收，然后部署。
+7. 你的卡片出现在 https://www.seeedstudio.com/sticky/playground/。
+```
 
-安装 Node.js 20 或更高版本，在仓库根目录执行：
+第 1–2 步由你完成，第 3–7 步由维护者完成，详见[第 9 节](#9-pr-合并之后)。
+
+## 5. 三种提交方式
+
+按你对 git 的熟悉程度选一种。三种方式最后都会向
+`Seeed-Projects/reterminal-sticky-playground-registry` 的 `main` 分支提交 pull request。
+
+### 方式 A：Fork 后用 git 操作（固件推荐）
+
+1. 在 GitHub 上 Fork 仓库：打开
+   <https://github.com/Seeed-Projects/reterminal-sticky-playground-registry>，点击 **Fork**。
+2. 克隆你的 Fork 并新建分支：
+
+   ```bash
+   git clone https://github.com/<你的账号>/reterminal-sticky-playground-registry.git
+   cd reterminal-sticky-playground-registry
+   git checkout -b add-my-design
+   ```
+
+3. 复制对应类型的模板并填写（细节见各自的指南）：
+
+   ```bash
+   cp -R printables/_template printables/my-design     # 打印件
+   cp -R firmwares/_template  firmwares/my-firmware    # 固件
+   ```
+
+4. 运行本地检查：
+
+   ```bash
+   npm test
+   npm run validate
+   ```
+
+5. 提交并推送：
+
+   ```bash
+   git add printables/my-design
+   git commit -m "feat: add My Design printable"
+   git push -u origin add-my-design
+   ```
+
+6. 打开 pull request。GitHub 会在你的 Fork 页面显示 **Compare & pull request** 按钮，
+   点击后确认目标是 `Seeed-Projects/reterminal-sticky-playground-registry` 的 `main`，
+   然后填写描述框里自动出现的模板。
+
+### 方式 B：GitHub 网页操作（不需要 git）
+
+适合打印件，以及固件元数据的小修改。
+
+1. Fork 仓库（同方式 A 第 1 步）。
+2. 在你的 Fork 里打开 `printables/` 目录，点击 **Add file → Create new file**。
+3. 在文件名框里输入 `my-design/printable.json`。输入 `/` 会自动创建目录。把
+   [`printables/_template/printable.json`](printables/_template/printable.json)
+   的内容粘贴进来并修改。
+4. 点击 **Commit changes…**，选择 **Create a new branch**，命名为 `add-my-design`，提交。
+5. 仍在这个分支上，打开 `printables/my-design/`，点击 **Add file → Upload files**
+   上传照片：把文件拖进去，然后把上传区域上方显示的路径改成
+   `printables/my-design/assets/preview.jpg`，提交。
+6. 用 **Create new file** 重复第 5 步，创建 `printables/my-design/README.md`。
+7. GitHub 会显示一条横幅，提示从你的分支发起 pull request。点击它，确认目标是
+   Seeed 仓库的 `main`，填写模板。
+
+GitHub Actions 会运行与 `npm run validate` 相同的检查；如果有问题，PR 会显示红叉，
+日志会告诉你要改哪个字段。在你的分支上修改文件，检查会自动重新运行。
+
+### 方式 C：在浏览器里直接改已有文件（只用于更新）
+
+修正错别字、更换链接、给已有卡片加版本时：
+
+1. 在 GitHub 上打开那个文件（例如 `printables/sticky-wallet-case/printable.json`）。
+2. 点击铅笔图标（**Edit this file**）。如果需要，GitHub 会自动帮你 Fork。
+3. 修改内容，点击 **Commit changes…**，选择 **Propose changes**。
+4. GitHub 打开 pull request 表单，填写模板。
+
+## 6. 所有贡献共同遵守的规则
+
+以下规则由 `npm run validate` 和人工审核共同保证。
+
+| 规则 | 说明 |
+|---|---|
+| 一个目录一份贡献 | 一个固件或一个设计的全部文件都放在自己的目录里。同一个 PR 不要改动其他目录。 |
+| 目录名 = `id` | 只用小写字母、数字和单个连字符：`^[a-z0-9]+(?:-[a-z0-9]+)*$`，2–64 个字符。例如 `sticky-2048`、`wallet-case`。元数据文件里的 `id` 必须与目录名完全一致。 |
+| 只用 HTTPS 链接 | 所有网址字段必须以 `https://` 开头。 |
+| 图片放在 `assets/` 下 | 引用写成 `assets/<文件名>`。固件支持 PNG、JPG、WebP、静态 SVG；打印件支持 PNG、JPG、WebP。预览图最大 5 MB，标识图最大 1 MB。 |
+| 真实图片 | 预览图必须是 reTerminal Sticky 真机上的截图或照片，不接受渲染图或素材图。 |
+| 卡片文字用英文 | `name`、`summary`、`description`、`alt` 和 README 使用英文，因为网站面向全球访客。 |
+| 不含密钥 | 源码、配置和 README 中不包含 Wi-Fi 密码、API key、token 或私钥。用占位符代替，并说明运行时如何配置。 |
+| 自己的作品或明确署名 | `author` 写创作者本人或团队。替他人提交开源设计或固件时，`author` 写原作者，`download.url` / `source.url` 指向原始页面。 |
+| 元数据文件是严格的 | 出现未知字段会导致校验失败。请复制模板后修改值，不要自行添加新键。 |
+
+## 7. 本地自检
+
+安装 [Node.js](https://nodejs.org/) 20 或更高版本，在仓库根目录执行：
 
 ```bash
-npm test
-npm run validate
+npm test          # 校验脚本自身的单元测试
+npm run validate  # 检查 firmwares/ 和 printables/ 下的全部目录
 ```
 
-校验脚本会检查全部固件和打印设计目录，仓库一致时打印
-`Registry validation passed (N firmware(s), M printable(s)).`。
-GitHub Actions 会对每个 pull request 运行同样的命令。
+成功时输出：
 
-## PR 审核
+```text
+Registry validation passed (12 firmware(s), 5 printable(s)).
+```
 
-1. 提交 pull request，并在模板中勾选贡献类型。
-2. GitHub Actions 校验 Registry；对源码模式固件，还会编译项目并把固件作为 PR 产物附上。
-3. 维护者审核元数据、图片、链接、许可证，固件贡献还会核对真机测试记录。
-4. 检查通过且审核完成后合并。
+失败时会逐条列出问题，精确到文件和字段：
 
-## PR 合并之后
+```text
+Registry validation failed with 2 error(s):
+- printables/my-design/printable.json.download.url: must use HTTPS
+- printables/my-design/printable.json.preview.image: references a missing file: assets/preview.jpg
+```
 
-合并 Registry 的 pull request 不会直接发布到正式网站。Sticky 网站锁定一个经过审核
-的 Registry 提交，维护者按下面的顺序发布：
+文件名后面的部分是 JSON 里的路径：`download.url` 表示 `download` 对象里的 `url`
+键。改好字段，再跑一次，直到通过。
+
+校验脚本对两类贡献都会检查：
+
+- 目录名与 `id` 一致；
+- 必填字段齐全，且没有未知字段；
+- 字符串在长度限制内，枚举字段使用允许的值；
+- 网址使用 HTTPS；
+- 引用的图片存在、后缀允许、内容是真实图片数据、大小不超限；
+- `README.md` 存在。
+
+固件还会额外检查源码目录、编译设置、manifest、`.bin` 大小、SHA-256 和烧录地址，
+见固件指南。
+
+一句话总结：先在自己电脑上让校验变绿，PR 上就不会红。
+
+## 8. PR 审核
+
+1. 提交 pull request 并填写模板。**Contribution type** 只勾一项，只需完成对应的那一节。
+2. GitHub Actions 运行 `npm test` 和 `npm run validate`。源码模式固件还会被编译，
+   固件作为 PR 产物附在检查结果里。出现红叉说明有失败，点 **Details** 看日志。
+3. 维护者审核元数据、图片、链接、许可证，固件贡献还会核对真机测试记录。审核意见会
+   以评论形式出现在 PR 上；回复或直接往同一分支推送修改即可。
+4. 检查全绿且审核完成后，维护者合并。
+
+一般几个工作日内会有回应。如果 PR 超过两周没有动静，请在 PR 里留言提醒。
+
+## 9. PR 合并之后
+
+合并不会立刻上线。Sticky 网站只读取一个锁定的 Registry 提交，维护者按批次发布：
 
 1. 合并 Registry pull request。
 2. 源码模式固件需等待 Registry `main` 的工作流发布固件 Release。
@@ -81,11 +259,43 @@ GitHub Actions 会对每个 pull request 运行同样的命令。
 5. 固件从本地页面烧录到真机验收。
 6. 合并到 Sticky 网站 `main` 并部署。
 
-第 6 步完成后，新卡片出现在 <https://www.seeedstudio.com/sticky/playground/>。
+第 6 步完成后，你的卡片出现在 <https://www.seeedstudio.com/sticky/playground/>。
 
 一句话总结：合并公开 PR 是进入待发布队列，网站更新锁定版本后才正式上线。
 
-## 更新已有贡献
+## 10. 更新或移除已有贡献
 
-直接修改你目录下的文件，再提交新的 pull request。固件更新把新版本放在
-`flash.versions` 最前面，详见固件指南；打印设计更新可以改卡片文字、照片、分类或下载页。
+**更新。** 修改你目录下的文件，用上面任一方式再提一个 pull request。模板里勾选
+**Firmware: update to an existing firmware** 或 **3D printable design**。固件更新把
+新版本放在 `flash.versions` 最前面，细节见固件指南。
+
+**移除。** 提交一个删除该目录的 pull request，并在描述里说明原因。如果仍有用户依赖，
+维护者可能保留目录并标记为不再维护。
+
+**转交。** 由他人接手维护时，提交一个修改 `author` 和链接的 PR，并在描述里提到
+原作者，方便对方确认。
+
+## 11. 常见问题
+
+**一个 PR 能提交多个设计或固件吗？**
+请一个目录一个 PR。这样审核更聚焦，每张卡片也能独立发布。
+
+**我的设计发在多个平台，`download.url` 填哪个？**
+填你维护得最勤的那个页面，其余的在 README 里提一下。
+
+**我发现别人做的设计很适合 Sticky，可以帮忙加上吗？**
+可以，前提是其许可证允许转发链接并注明出处。`author` 写原设计者，`download.url`
+指向对方的页面，并在 PR 里说明你是代为提交。
+
+**必须在本地跑 `npm run validate` 吗？**
+不是必须。GitHub Actions 会在 PR 上运行它。本地跑只是几秒钟就能拿到结果，而不用等几分钟。
+
+**校验说 `contains unsupported field "..."`。**
+元数据文件只接受各自指南里列出的字段。删掉多出来的键，或检查合法键名是否拼错。
+
+**提交前怎么在自己的设备上测试固件？**
+用 ESP-IDF 本地编译并 `idf.py flash`，或者提交 PR 后使用 GitHub Actions 生成的 PR
+产物。固件指南对两种方式都有说明。
+
+**有不清楚的地方问谁？**
+在本仓库开一个 issue，或直接在 pull request 里提问。

--- a/docs/contributing-firmware.md
+++ b/docs/contributing-firmware.md
@@ -15,6 +15,24 @@ card and flashing page.
 For the Chinese guide, see [contributing-firmware.zh-CN.md](contributing-firmware.zh-CN.md).
 Shared review and release steps live in [CONTRIBUTING.md](../CONTRIBUTING.md).
 
+## Contents
+
+- [Contribution result](#contribution-result)
+- [Required pull request contents](#required-pull-request-contents)
+- [Create a contribution](#create-a-contribution)
+- [firmware.json](#firmwarejson) and its [field reference](#field-reference)
+- [Contribution paths](#contribution-paths): [source](#source-contribution) or [firmware-only](#firmware-only-package) (with the [manifest.json reference](#manifestjson-for-a-firmware-only-package))
+- [Official Sticky firmware updates](#official-sticky-firmware-updates)
+- [Source contribution requirements](#source-contribution-requirements)
+- [Optional local ESP-IDF build](#optional-local-esp-idf-build)
+- [Local validation](#local-validation) and [common validation errors](#common-validation-errors)
+- [Submitting the pull request](#submitting-the-pull-request)
+- [Physical device test](#physical-device-test)
+- [Pull request review and automation](#pull-request-review-and-automation)
+- [What happens after merge](#what-happens-after-merge)
+- [Updating an existing firmware](#updating-an-existing-firmware)
+- [Pull request checklist](#pull-request-checklist)
+
 ## Contribution result
 
 A published community contribution provides this user flow:
@@ -176,25 +194,92 @@ Normal third-party submissions use `"group": "community"`,
 }
 ```
 
-### Catalog fields
+### Field reference
 
-| Field | Community contribution value |
-|---|---|
-| `group` | `community` |
-| `catalogSection` | `community` |
-| `category` | One value from `ereader`, `productivity`, `personal`, `weather`, `finance`, `tools`, `fun`, or `smart-home` |
-| `mode` | `flash` |
-| `status` | `experimental`, `beta`, or `stable` according to project maturity |
-| `author.name` | Required author or team name shown on the website |
-| `author.url` | Optional HTTPS link opened when the author name is selected |
-| `origin.name` | Optional display source shown on the website |
-| `origin.url` | Optional HTTPS link opened when the display source is selected |
-| `source.url` | Upstream source repository for both contribution paths |
-| `source.license` | Source license identifier, required for firmware-only contributions |
-| `source.path` | Local source directory for the source path, normally `source` |
-| `build.*` | Build metadata supplied together with `source.path` |
-| `flash.versions[].sourceBuild` | Set to `true` when GitHub Actions builds the submitted source |
-| `flash.versions[].manifestPath` | Local manifest used by a firmware-only contribution |
+`firmware.json` is a strict JSON object: every key below is either required or
+optional, and **any other key makes validation fail**. The formal definition is
+[`schemas/firmware.schema.json`](../schemas/firmware.schema.json). Community
+contributions fill in the "Community value" column; partner and official
+entries are coordinated with Seeed.
+
+#### Identity and catalog placement
+
+| Field | Type | Required | Limits | Community value / what to write |
+|---|---|---|---|---|
+| `schemaVersion` | integer | Yes | must be `1` | `1` |
+| `id` | string | Yes | 2–64 chars, `^[a-z0-9]+(?:-[a-z0-9]+)*$` | Same as the directory name, for example `sticky-2048` |
+| `name` | string | Yes | 1–80 chars | Card title shown on the website |
+| `group` | string | Yes | `official`, `partner`, `community` | `community` |
+| `catalogSection` | string | Yes | `official`, `platform`, `community`, `draft` | `community`. Cards in `draft` are not published |
+| `category` | string | Required for `community` | `ereader`, `productivity`, `personal`, `weather`, `finance`, `tools`, `fun`, `smart-home` | The filter that shows your card; see the table below |
+| `mode` | string | Yes | `flash`, `external`, `template`, `download` | `flash` (browser flashing). The other modes are reserved for coordinated entries |
+| `status` | string | Yes | `experimental`, `beta`, `stable` | Project maturity; shown as a badge |
+| `summary` | string | Yes | 1–140 chars | One sentence under the title |
+| `description` | string | Yes | 1–800 chars | Two or three sentences: what it does, what services it needs, what users should expect |
+| `tags` | array of strings | No | up to 6 items, each 1–32 chars, unique | Short labels such as `offline`, `wifi`, `touch` |
+
+Community firmware categories:
+
+| Value | Filter label | Use it for |
+|---|---|---|
+| `ereader` | eReader | Book, article, and document readers |
+| `productivity` | Productivity | Task lists, calendars, notes, timers, dashboards for work |
+| `personal` | Personal | Habit trackers, prayer times, journals, personal reminders |
+| `weather` | Weather | Weather, air quality, tides, forecasts |
+| `finance` | Finance | Prices, portfolios, budgets |
+| `tools` | Tools | Utilities, calculators, converters, device diagnostics |
+| `fun` | Fun | Games, art, toys, novelty displays |
+| `smart-home` | Smart Home | Home Assistant, sensors, controls, presence |
+
+#### Attribution and links
+
+| Field | Type | Required | Limits | What to write |
+|---|---|---|---|---|
+| `author.name` | string | Required for `community` | 1–80 chars | Author or team name shown on the card |
+| `author.url` | string | No | HTTPS URL | Profile or project page opened when the name is selected |
+| `origin.name` | string | No | 1–80 chars | Display name of where the firmware comes from, for example `Project repository` or a community name |
+| `origin.url` | string | No | HTTPS URL | Link for `origin.name` |
+| `source.url` | string | Yes | HTTPS URL | Upstream source repository, for both contribution paths |
+| `source.license` | string | Required for firmware-only | 1–80 chars | SPDX-style license id such as `MIT`, `GPL-3.0`, `Apache-2.0` |
+| `source.path` | string | Required for source contributions | relative path inside the directory, normally `source` | Directory containing the ESP-IDF project |
+| `support.url` | string | Yes | HTTPS URL | Where users report problems, normally the issue tracker |
+| `documentationUrl` | string | No | HTTPS URL | User documentation, normally the upstream README |
+
+#### Compatibility and images
+
+| Field | Type | Required | Limits | What to write |
+|---|---|---|---|---|
+| `compatibility.devices` | array | Yes | exactly `["reterminal-sticky"]` | Always `["reterminal-sticky"]` |
+| `compatibility.notes` | string | No | up to 400 chars | Tested hardware revision, required accessories, known limits |
+| `assets.preview` | string | Yes | `assets/<file>.(png\|jpg\|jpeg\|webp\|svg)`, ≤ 5 MB | Real Sticky screenshot or photo of the firmware running |
+| `assets.previewAlt` | string | Yes | 1–180 chars | One sentence describing the preview |
+| `assets.logo` | string | No | same pattern, ≤ 1 MB | Optional project logo. Partner entries use their official logo here and in `preview` |
+
+#### Build settings (source contributions only)
+
+| Field | Type | Required | Limits | What to write |
+|---|---|---|---|---|
+| `build.system` | string | Yes | must be `esp-idf` | `esp-idf` |
+| `build.version` | string | Yes | up to 64 chars, `^[A-Za-z0-9][A-Za-z0-9._-]*$` | ESP-IDF version the project builds with: `v5.4`, `v5.3.2`, `latest` |
+| `build.target` | string | Yes | up to 40 chars | `esp32s3` (reTerminal Sticky uses an ESP32-S3) |
+| `build.projectPath` | string | Yes | relative path | Same value as `source.path` |
+
+Omit the whole `build` object for firmware-only packages.
+
+#### Firmware versions
+
+| Field | Type | Required | Limits | What to write |
+|---|---|---|---|---|
+| `flash.versions` | array | Yes | at least 1, newest first | One entry per published version |
+| `flash.versions[].version` | string | Yes | 1–40 chars, unique | Version label shown to users, for example `1.0.0` |
+| `flash.versions[].channel` | string | Yes | `experimental`, `beta`, `stable` | Maturity of that version |
+| `flash.versions[].sourceBuild` | boolean | Source contributions: `true` on the newest version | — | GitHub Actions builds this version from `source/` |
+| `flash.versions[].manifestPath` | string | Firmware-only: required on every version | `firmware/<version>/manifest.json` | Path to the committed manifest |
+| `flash.versions[].manifestUrl`, `manifestSha256`, `releaseUrl` | string | Maintainer use | — | Used for versions that already live in a Registry GitHub Release |
+| `flash.notes` | array | No | 1–12 items | Installation notes shown on the flashing page; each item has `title` (≤ 100) and `description` (≤ 500) |
+
+Each version uses exactly one delivery method: `sourceBuild: true`, or
+`manifestPath`, or the Release triplet.
 
 `author` and `origin` are website attribution fields. The `source` object keeps
 the technical source repository, license, and local build path used during
@@ -205,7 +290,7 @@ Seeed or partner work. Partner entries use `"group": "partner"`,
 `"catalogSection": "platform"`, `"mode": "flash"`, official project links,
 and official identity assets. Author attribution is optional for partner and
 official cards because their platform identity is represented by the
-integration name and official links. Normal community pull requests target the
+firmware name and official links. Normal community pull requests target the
 `community` section. Maintainers may
 temporarily use `draft` for migrated entries that are still waiting for a
 complete firmware package; draft entries are not published to Sticky
@@ -237,6 +322,57 @@ result in the integration README and pull request.
   "license": "MIT"
 }
 ```
+
+#### manifest.json for a firmware-only package
+
+Each version directory contains one `manifest.json` and the `.bin` files it
+lists. The website reads this manifest to flash the device in the browser.
+
+```json
+{
+  "name": "My Firmware",
+  "version": "1.0.0",
+  "flashSize": "16MB",
+  "flashMode": "dio",
+  "flashFreq": "80m",
+  "baudRate": 460800,
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        { "path": "bootloader.bin",      "offset": 0,      "size": 21344,   "sha256": "<sha256>" },
+        { "path": "partition-table.bin", "offset": 32768,  "size": 3072,    "sha256": "<sha256>" },
+        { "path": "my-firmware.bin",     "offset": 65536,  "size": 1523712, "sha256": "<sha256>" }
+      ]
+    }
+  ]
+}
+```
+
+| Field | Required | What to write |
+|---|---|---|
+| `name` | Yes | Same as `firmware.json` `name` |
+| `version` | Yes | Same as the `flash.versions[].version` that points at this manifest |
+| `flashSize` | No | Flash size of the device, `16MB` for reTerminal Sticky; used to reject parts that overflow |
+| `flashMode`, `flashFreq`, `baudRate`, `new_install_prompt_erase` | No | Passed to the browser flasher; the values above work for Sticky |
+| `builds[].chipFamily` | Yes | `ESP32-S3` |
+| `builds[].parts[].path` | Yes | File name only, in the same directory as the manifest, ending in `.bin` |
+| `builds[].parts[].offset` | Yes | Flash address in bytes (decimal), taken from your build's `flasher_args.json` |
+| `builds[].parts[].size` | Yes | Exact byte size of the file |
+| `builds[].parts[].sha256` | Yes | Lowercase SHA-256 of the file |
+
+Parts must not overlap and each `.bin` may not exceed 32 MB. Get the numbers
+with:
+
+```bash
+cd firmwares/my-firmware/firmware/1.0.0
+wc -c *.bin                 # size
+shasum -a 256 *.bin         # sha256 (macOS/Linux); certutil -hashfile file SHA256 on Windows
+```
+
+Offsets come from ESP-IDF's `build/flasher_args.json` (`flash_files`) or the
+upstream project's release notes. A single merged image starts at offset `0`.
 
 ## Official Sticky firmware updates
 
@@ -332,6 +468,63 @@ The validator checks:
 For source contributions, manifest and firmware-file checks run after GitHub
 Actions builds the project. For firmware-only contributions, they run directly
 against the files committed in the PR.
+
+### Common validation errors
+
+| Error text | Cause | Fix |
+|---|---|---|
+| `firmwares/my-firmware: is missing firmware.json` | File not created or misnamed | Create `firmwares/my-firmware/firmware.json` |
+| `...firmware.json: contains unsupported field "..."` | A key that is not in the field reference | Remove it or fix the spelling |
+| `...firmware.json.id: must match the directory name "..."` | `id` differs from the directory | Make them identical |
+| `...firmware.json.category: is required for community firmware entries` | Missing `category` | Add one of the eight values |
+| `...firmware.json.author: is required for community firmware` | Missing `author` | Add `author.name` |
+| `...firmware.json.source.license: is required for firmware-only packages` | Firmware-only without a license id | Add `source.license` |
+| `...firmware.json.build: is required when source.path is provided` | Source contribution without `build` | Add the `build` object |
+| `...firmware.json.build.projectPath: must contain CMakeLists.txt for an ESP-IDF project` | `source/` is empty or points at the wrong directory | Commit the ESP-IDF project root under `source/` |
+| `...flash.versions[0].sourceBuild: must be true for a source contribution` | Newest version lacks `sourceBuild` | Set `"sourceBuild": true` on the first entry |
+| `...flash.versions[0]: must use exactly one firmware delivery method` | `sourceBuild` and `manifestPath` both set, or neither | Keep one |
+| `...manifestPath: must be inside the firmware/ directory` | Manifest stored elsewhere | Move to `firmware/<version>/manifest.json` |
+| `...manifestPath: version must match firmware version "1.0.0"` | Manifest `version` differs from `flash.versions[].version` | Make them identical |
+| `...parts[0].path: must be one .bin filename beside the manifest` | Path contains a directory or wrong extension | Put the file next to the manifest and use its bare name |
+| `...parts[0].size: expected 1523712 bytes but found 1523700` | Wrong `size` | Re-run `wc -c` and update |
+| `...parts[0].sha256: does not match the firmware file` | Wrong hash or file changed after hashing | Re-run `shasum -a 256` and update |
+| `...parts[1]: overlaps the previous firmware part` | `offset + size` of one part runs into the next | Check offsets against `flasher_args.json` |
+| `...assets.preview: does not contain a valid PNG file signature` | A JPG renamed to `.png` (or similar) | Use the real extension |
+| `...source.LICENSE: references a missing file: source/LICENSE` | License file missing from the source tree | Add `source/LICENSE` |
+
+## Submitting the pull request
+
+Any of the three methods in
+[CONTRIBUTING.md → Three ways to submit](../CONTRIBUTING.md#5-three-ways-to-submit)
+works; firmware is easiest with git because of the number of files.
+
+```bash
+git checkout -b add-my-firmware
+git add firmwares/my-firmware
+git commit -m "feat: add My Firmware 1.0.0"
+git push -u origin add-my-firmware
+```
+
+Then open the pull request against
+`Seeed-Projects/reterminal-sticky-playground-registry` / `main` and complete
+the template:
+
+1. Under **Contribution type**, tick one **Firmware:** line.
+2. Complete **Common verification**.
+3. In the **Firmware** section, fill in the name, directory, version, upstream
+   project, license, and (for firmware-only) the artifact origin and SHA-256.
+4. Tick the **Package type** and complete only the matching sub-list (source
+   contribution or firmware-only).
+5. Complete **Physical-device test** with the device revision, install method,
+   version, workflow tested, and the reboot/USB results.
+
+Title suggestion: `Add <Firmware Name> <version>`.
+
+Source contributions: after the PR is opened, GitHub Actions compiles the
+project. When the **Build <id>** job finishes, its page has an artifact named
+`firmware-<id>-<version>` containing `manifest.json` and the `.bin` files. You
+can download it and flash it with `esptool` or the browser flasher to complete
+the device test on the exact bytes reviewers will publish.
 
 ## Physical device test
 

--- a/docs/contributing-firmware.zh-CN.md
+++ b/docs/contributing-firmware.zh-CN.md
@@ -12,6 +12,24 @@
 英文指南请查看 [contributing-firmware.md](contributing-firmware.md)。
 两类贡献共用的审核与发布流程见 [CONTRIBUTING.zh-CN.md](../CONTRIBUTING.zh-CN.md)。
 
+## 目录
+
+- [贡献完成后，用户会得到什么](#贡献完成后用户会得到什么)
+- [PR 必须提供的文件](#pr-必须提供的文件)
+- [创建一份贡献](#创建一份贡献)
+- [firmware.json](#firmwarejson) 及其[字段说明](#字段说明)
+- [两种贡献方式](#两种贡献方式)：[源码模式](#源码模式) 或 [仅固件包](#仅固件包)（含 [manifest.json 说明](#仅固件包的-manifestjson)）
+- [Sticky 官方固件更新](#sticky-官方固件更新)
+- [源码模式要求](#源码模式要求)
+- [可选的本地 ESP-IDF 编译](#可选的本地-esp-idf-编译)
+- [本地自动检查](#本地自动检查) 及[常见校验报错](#常见校验报错)
+- [提交 pull request](#提交-pull-request)
+- [真实设备测试](#真实设备测试)
+- [PR 审核和自动编译](#pr-审核和自动编译)
+- [合并后如何进入 Sticky 官网](#合并后如何进入-sticky-官网)
+- [更新已有固件](#更新已有固件)
+- [PR 提交前清单](#pr-提交前清单)
+
 ## 贡献完成后，用户会得到什么
 
 一份正式发布的社区固件会形成下面这条用户流程：
@@ -177,25 +195,90 @@ cp -R firmwares/_template firmwares/my-firmware
 }
 ```
 
-### 关键字段
+### 字段说明
 
-| 字段 | 社区贡献填写方式 |
-|---|---|
-| `group` | 固定为 `community` |
-| `catalogSection` | 固定为 `community` |
-| `category` | 从 `ereader`、`productivity`、`personal`、`weather`、`finance`、`tools`、`fun`、`smart-home` 中选一个 |
-| `mode` | 固定为 `flash` |
-| `status` | 按成熟度填写 `experimental`、`beta` 或 `stable` |
-| `author.name` | 必填，网站显示的作者或团队名称 |
-| `author.url` | 选填，点击作者名称时打开的 HTTPS 链接 |
-| `origin.name` | 选填，网站显示的来源名称 |
-| `origin.url` | 选填，点击来源名称时打开的 HTTPS 链接 |
-| `source.url` | 两种贡献方式都填写上游源码仓库地址 |
-| `source.license` | 源码许可证名称；仅固件包模式必须填写 |
-| `source.path` | 源码模式填写本地源码目录，通常为 `source` |
-| `build.*` | 源码模式与 `source.path` 一起提供的构建配置 |
-| `flash.versions[].sourceBuild` | 源码由 GitHub Actions 编译时设置为 `true` |
-| `flash.versions[].manifestPath` | 仅固件包模式填写项目内的 manifest 路径 |
+`firmware.json` 是一个严格的 JSON 对象：下面每个键要么必填要么可选，
+**出现任何其他键都会导致校验失败**。正式定义见
+[`schemas/firmware.schema.json`](../schemas/firmware.schema.json)。社区贡献按
+“社区填法”一列填写；合作伙伴和官方条目由 Seeed 协调维护。
+
+#### 身份与目录位置
+
+| 字段 | 类型 | 必填 | 限制 | 社区填法 / 填什么 |
+|---|---|---|---|---|
+| `schemaVersion` | 整数 | 是 | 必须是 `1` | `1` |
+| `id` | 字符串 | 是 | 2–64 字符，`^[a-z0-9]+(?:-[a-z0-9]+)*$` | 与目录名相同，例如 `sticky-2048` |
+| `name` | 字符串 | 是 | 1–80 字符 | 网站上的卡片标题 |
+| `group` | 字符串 | 是 | `official`、`partner`、`community` | `community` |
+| `catalogSection` | 字符串 | 是 | `official`、`platform`、`community`、`draft` | `community`。`draft` 的卡片不会发布 |
+| `category` | 字符串 | `community` 必填 | `ereader`、`productivity`、`personal`、`weather`、`finance`、`tools`、`fun`、`smart-home` | 决定卡片出现在哪个筛选项下，见下表 |
+| `mode` | 字符串 | 是 | `flash`、`external`、`template`、`download` | `flash`（浏览器烧录）。其余模式保留给协调维护的条目 |
+| `status` | 字符串 | 是 | `experimental`、`beta`、`stable` | 项目成熟度，显示为徽标 |
+| `summary` | 字符串 | 是 | 1–140 字符 | 标题下方的一句话 |
+| `description` | 字符串 | 是 | 1–800 字符 | 两三句话：做什么、需要哪些服务、用户会得到什么 |
+| `tags` | 字符串数组 | 否 | 最多 6 项，每项 1–32 字符，不重复 | 短标签，例如 `offline`、`wifi`、`touch` |
+
+社区固件分类：
+
+| 值 | 筛选项名称 | 适用范围 |
+|---|---|---|
+| `ereader` | eReader | 图书、文章、文档阅读器 |
+| `productivity` | Productivity | 待办、日历、笔记、计时器、工作看板 |
+| `personal` | Personal | 习惯打卡、礼拜时间、日记、个人提醒 |
+| `weather` | Weather | 天气、空气质量、潮汐、预报 |
+| `finance` | Finance | 行情、持仓、预算 |
+| `tools` | Tools | 实用工具、计算器、换算、设备诊断 |
+| `fun` | Fun | 游戏、艺术、玩具、趣味显示 |
+| `smart-home` | Smart Home | Home Assistant、传感器、控制、在家检测 |
+
+#### 署名与链接
+
+| 字段 | 类型 | 必填 | 限制 | 填什么 |
+|---|---|---|---|---|
+| `author.name` | 字符串 | `community` 必填 | 1–80 字符 | 卡片上显示的作者或团队名 |
+| `author.url` | 字符串 | 否 | HTTPS 网址 | 点击名字时打开的主页或项目页 |
+| `origin.name` | 字符串 | 否 | 1–80 字符 | 固件来源的显示名，例如 `Project repository` 或某个社区名 |
+| `origin.url` | 字符串 | 否 | HTTPS 网址 | `origin.name` 的链接 |
+| `source.url` | 字符串 | 是 | HTTPS 网址 | 上游源码仓库，两种贡献方式都要填 |
+| `source.license` | 字符串 | 仅固件包必填 | 1–80 字符 | SPDX 风格的许可证标识，如 `MIT`、`GPL-3.0`、`Apache-2.0` |
+| `source.path` | 字符串 | 源码模式必填 | 目录内的相对路径，通常是 `source` | 存放 ESP-IDF 工程的目录 |
+| `support.url` | 字符串 | 是 | HTTPS 网址 | 用户反馈问题的地方，通常是 issue 页面 |
+| `documentationUrl` | 字符串 | 否 | HTTPS 网址 | 用户文档，通常是上游 README |
+
+#### 兼容性与图片
+
+| 字段 | 类型 | 必填 | 限制 | 填什么 |
+|---|---|---|---|---|
+| `compatibility.devices` | 数组 | 是 | 必须恰好是 `["reterminal-sticky"]` | 固定写 `["reterminal-sticky"]` |
+| `compatibility.notes` | 字符串 | 否 | 最长 400 字符 | 测试过的硬件版本、需要的配件、已知限制 |
+| `assets.preview` | 字符串 | 是 | `assets/<文件>.(png\|jpg\|jpeg\|webp\|svg)`，≤ 5 MB | 固件运行中的真实 Sticky 截图或照片 |
+| `assets.previewAlt` | 字符串 | 是 | 1–180 字符 | 一句话描述预览图 |
+| `assets.logo` | 字符串 | 否 | 同上格式，≤ 1 MB | 可选的项目标识。合作伙伴条目在这里和 `preview` 都使用官方 logo |
+
+#### 编译设置（仅源码模式）
+
+| 字段 | 类型 | 必填 | 限制 | 填什么 |
+|---|---|---|---|---|
+| `build.system` | 字符串 | 是 | 必须是 `esp-idf` | `esp-idf` |
+| `build.version` | 字符串 | 是 | 最长 64 字符，`^[A-Za-z0-9][A-Za-z0-9._-]*$` | 项目使用的 ESP-IDF 版本：`v5.4`、`v5.3.2`、`latest` |
+| `build.target` | 字符串 | 是 | 最长 40 字符 | `esp32s3`（reTerminal Sticky 使用 ESP32-S3） |
+| `build.projectPath` | 字符串 | 是 | 相对路径 | 与 `source.path` 相同 |
+
+仅固件包模式请整个省略 `build` 对象。
+
+#### 固件版本
+
+| 字段 | 类型 | 必填 | 限制 | 填什么 |
+|---|---|---|---|---|
+| `flash.versions` | 数组 | 是 | 至少 1 项，最新版本在最前 | 每个已发布版本一项 |
+| `flash.versions[].version` | 字符串 | 是 | 1–40 字符，不重复 | 展示给用户的版本号，例如 `1.0.0` |
+| `flash.versions[].channel` | 字符串 | 是 | `experimental`、`beta`、`stable` | 该版本的成熟度 |
+| `flash.versions[].sourceBuild` | 布尔 | 源码模式：最新版本填 `true` | — | 由 GitHub Actions 从 `source/` 编译这个版本 |
+| `flash.versions[].manifestPath` | 字符串 | 仅固件包：每个版本必填 | `firmware/<version>/manifest.json` | 已提交的 manifest 路径 |
+| `flash.versions[].manifestUrl`、`manifestSha256`、`releaseUrl` | 字符串 | 维护者使用 | — | 用于已经存放在 Registry GitHub Release 里的版本 |
+| `flash.notes` | 数组 | 否 | 1–12 项 | 烧录页上显示的安装提示；每项含 `title`（≤ 100）和 `description`（≤ 500） |
+
+每个版本只能用一种交付方式：`sourceBuild: true`，或 `manifestPath`，或 Release 三元组。
 
 `author` 和 `origin` 用于网站署名展示；`source` 保存审核与固件打包使用的源码仓库、
 许可证和本地编译路径。
@@ -231,6 +314,56 @@ Release，供 Sticky 测试分支读取。
   "license": "MIT"
 }
 ```
+
+#### 仅固件包的 manifest.json
+
+每个版本目录里有一个 `manifest.json` 和它列出的 `.bin` 文件。网站读取这份 manifest
+在浏览器里烧录设备。
+
+```json
+{
+  "name": "My Firmware",
+  "version": "1.0.0",
+  "flashSize": "16MB",
+  "flashMode": "dio",
+  "flashFreq": "80m",
+  "baudRate": 460800,
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        { "path": "bootloader.bin",      "offset": 0,      "size": 21344,   "sha256": "<sha256>" },
+        { "path": "partition-table.bin", "offset": 32768,  "size": 3072,    "sha256": "<sha256>" },
+        { "path": "my-firmware.bin",     "offset": 65536,  "size": 1523712, "sha256": "<sha256>" }
+      ]
+    }
+  ]
+}
+```
+
+| 字段 | 必填 | 填什么 |
+|---|---|---|
+| `name` | 是 | 与 `firmware.json` 的 `name` 相同 |
+| `version` | 是 | 与指向这份 manifest 的 `flash.versions[].version` 相同 |
+| `flashSize` | 否 | 设备闪存大小，reTerminal Sticky 为 `16MB`；用来拒绝超出范围的分区 |
+| `flashMode`、`flashFreq`、`baudRate`、`new_install_prompt_erase` | 否 | 传给浏览器烧录器；上面的值适用于 Sticky |
+| `builds[].chipFamily` | 是 | `ESP32-S3` |
+| `builds[].parts[].path` | 是 | 只写文件名，与 manifest 同目录，以 `.bin` 结尾 |
+| `builds[].parts[].offset` | 是 | 烧录地址（十进制字节），来自编译产物的 `flasher_args.json` |
+| `builds[].parts[].size` | 是 | 文件的精确字节数 |
+| `builds[].parts[].sha256` | 是 | 文件的小写 SHA-256 |
+
+各分区不能重叠，单个 `.bin` 不超过 32 MB。数值可以这样获取：
+
+```bash
+cd firmwares/my-firmware/firmware/1.0.0
+wc -c *.bin                 # 大小
+shasum -a 256 *.bin         # sha256（macOS/Linux）；Windows 用 certutil -hashfile 文件名 SHA256
+```
+
+烧录地址来自 ESP-IDF 的 `build/flasher_args.json`（`flash_files`）或上游项目的发布说明。
+单个合并镜像从地址 `0` 开始。
 
 一句话总结：提交源码时由 Action 产出固件；直接提交固件时由作者提供完整烧录包。
 
@@ -326,6 +459,58 @@ npm run validate
 
 源码模式的 manifest 和固件文件检查会在 Action 编译后执行；仅固件包模式直接检查
 PR 中提交的文件。
+
+### 常见校验报错
+
+| 报错文字 | 原因 | 修法 |
+|---|---|---|
+| `firmwares/my-firmware: is missing firmware.json` | 文件没创建或名字不对 | 创建 `firmwares/my-firmware/firmware.json` |
+| `...firmware.json: contains unsupported field "..."` | 出现了字段说明里没有的键 | 删掉或修正拼写 |
+| `...firmware.json.id: must match the directory name "..."` | `id` 与目录名不一致 | 改成一样 |
+| `...firmware.json.category: is required for community firmware entries` | 缺 `category` | 从八个值里选一个 |
+| `...firmware.json.author: is required for community firmware` | 缺 `author` | 补上 `author.name` |
+| `...firmware.json.source.license: is required for firmware-only packages` | 仅固件包没写许可证 | 补上 `source.license` |
+| `...firmware.json.build: is required when source.path is provided` | 源码模式缺 `build` | 补上 `build` 对象 |
+| `...firmware.json.build.projectPath: must contain CMakeLists.txt for an ESP-IDF project` | `source/` 为空或指错目录 | 把 ESP-IDF 工程根目录提交到 `source/` |
+| `...flash.versions[0].sourceBuild: must be true for a source contribution` | 最新版本没有 `sourceBuild` | 第一项加上 `"sourceBuild": true` |
+| `...flash.versions[0]: must use exactly one firmware delivery method` | `sourceBuild` 和 `manifestPath` 同时出现，或都没有 | 只保留一种 |
+| `...manifestPath: must be inside the firmware/ directory` | manifest 放错位置 | 移到 `firmware/<version>/manifest.json` |
+| `...manifestPath: version must match firmware version "1.0.0"` | manifest 的 `version` 与 `flash.versions[].version` 不一致 | 改成一样 |
+| `...parts[0].path: must be one .bin filename beside the manifest` | 路径带目录或后缀不对 | 文件放在 manifest 旁边，只写文件名 |
+| `...parts[0].size: expected 1523712 bytes but found 1523700` | `size` 写错 | 重新 `wc -c` 后更新 |
+| `...parts[0].sha256: does not match the firmware file` | 哈希写错，或算完哈希后文件又变了 | 重新 `shasum -a 256` 后更新 |
+| `...parts[1]: overlaps the previous firmware part` | 某个分区的 `offset + size` 压到了下一个分区 | 对照 `flasher_args.json` 检查地址 |
+| `...assets.preview: does not contain a valid PNG file signature` | JPG 改名成了 `.png`（或类似情况） | 使用真实后缀 |
+| `...source.LICENSE: references a missing file: source/LICENSE` | 源码目录缺许可证文件 | 加上 `source/LICENSE` |
+
+## 提交 pull request
+
+[CONTRIBUTING.zh-CN.md → 三种提交方式](../CONTRIBUTING.zh-CN.md#5-三种提交方式)
+里的任一方式都可以；固件文件较多，用 git 最方便。
+
+```bash
+git checkout -b add-my-firmware
+git add firmwares/my-firmware
+git commit -m "feat: add My Firmware 1.0.0"
+git push -u origin add-my-firmware
+```
+
+然后向 `Seeed-Projects/reterminal-sticky-playground-registry` 的 `main` 发起 pull
+request，并填写模板：
+
+1. **Contribution type** 勾选一条 **Firmware:** 开头的类型。
+2. 完成 **Common verification**。
+3. 在 **Firmware** 一节填写名称、目录、版本、上游项目、许可证，仅固件包还要填产物来源和 SHA-256。
+4. 勾选 **Package type**，只完成对应的子清单（源码模式或仅固件包）。
+5. 完成 **Physical-device test**：设备版本、安装方式、版本号、测试过的主流程、重启/USB 结果。
+
+标题建议：`Add <Firmware Name> <version>`。
+
+源码模式：PR 打开后 GitHub Actions 会编译项目。**Build <id>** 任务完成后，其页面上有
+名为 `firmware-<id>-<version>` 的产物，里面是 `manifest.json` 和 `.bin` 文件。你可以
+下载后用 `esptool` 或浏览器烧录器烧录，用审核者将要发布的同一份字节完成真机测试。
+
+一句话总结：推分支、开 PR、按模板填固件信息和真机测试记录。
 
 ## 真实设备测试
 

--- a/docs/contributing-printables.md
+++ b/docs/contributing-printables.md
@@ -1,60 +1,127 @@
 # Contributing a 3D printable design
 
-This guide covers cases, stands, mounts, and accessories for the **3D Printables**
+This guide covers cases, stands, mounts, and accessories for the
+[**3D Printables**](https://www.seeedstudio.com/sticky/playground/3d-printables/)
 page of the Sticky Playground. It is written for makers who publish models on
 Printables, MakerWorld, Thingiverse, GrabCAD, or GitHub. You do not need to
-know anything about firmware.
+know anything about firmware or ESP-IDF.
 
 For the Chinese guide, see [contributing-printables.zh-CN.md](contributing-printables.zh-CN.md).
-Shared review and release steps live in [CONTRIBUTING.md](../CONTRIBUTING.md).
+Rules shared with firmware contributions, the three ways to open a pull
+request, and the release flow are in [CONTRIBUTING.md](../CONTRIBUTING.md).
 
-## What you submit
+## Contents
 
-You submit one card, not the model files:
+1. [What you submit](#1-what-you-submit)
+2. [What visitors see](#2-what-visitors-see)
+3. [Files in your directory](#3-files-in-your-directory)
+4. [printable.json field reference](#4-printablejson-field-reference)
+5. [Categories](#5-categories)
+6. [The preview photo](#6-the-preview-photo)
+7. [The README](#7-the-readme)
+8. [Step by step](#8-step-by-step)
+9. [Validation errors and how to fix them](#9-validation-errors-and-how-to-fix-them)
+10. [Updating a design](#10-updating-a-design)
+11. [Worked example](#11-worked-example)
+12. [Checklist](#12-checklist)
 
-- a small `printable.json` file with the text shown on the card;
-- one photo of the printed design fitted on a real reTerminal Sticky;
-- a short README with print settings and assembly notes.
+## 1. What you submit
 
-The model files stay on your own download page. The Sticky website shows your
-card and sends visitors to that page with a **View on …** button.
+You submit one **card**, not the model files:
+
+| File | Purpose | Required |
+|---|---|---|
+| `printables/<design-id>/printable.json` | The text and links shown on the card | Yes |
+| `printables/<design-id>/assets/preview.jpg` | Photo of the printed design fitted on reTerminal Sticky | Yes |
+| `printables/<design-id>/README.md` | Print settings, assembly notes, and the download link in prose | Yes |
+
+The STL / 3MF / STEP files stay on your own download page. The Sticky website
+shows your card and sends visitors to that page with a **View on …** button.
+This keeps the files under your control: you can update them, add remixes, or
+change the license without a new pull request here.
+
+## 2. What visitors see
+
+On the 3D Printables page every design is one card in a grid, with a category
+filter on the left. A card shows, from top to bottom:
+
+1. your `preview.image` photo (cropped to about 4:3);
+2. the category pill (for example **Cases**) and any `tags`;
+3. `name` as the title;
+4. `summary` as one or two lines under the title;
+5. an **Author** row showing `author.name`, linked to `author.url` if you gave one;
+6. a full-width **View on `<download.platform>`** button that opens `download.url` in a new tab.
+
+`description` is stored for the card's detail view and for search; it is not
+shown in the grid today, so put the essential message in `summary`.
+
+## 3. Files in your directory
 
 ```text
 printables/
-  my-case/
-    printable.json
-    README.md
+  my-case/                 <- directory name = id
+    printable.json         <- card metadata (this guide, section 4)
+    README.md              <- print settings and assembly notes (section 7)
     assets/
-      preview.jpg
+      preview.jpg          <- photo referenced by preview.image (section 6)
 ```
 
-## What visitors see
+Rules for the directory name (`<design-id>`):
 
-1. The visitor opens Sticky Playground and selects **3D Printables**.
-2. The visitor filters by category and opens your card.
-3. The visitor selects **View on Printables** (or the platform you named).
-4. The visitor downloads the files from your page.
+- lowercase letters, digits, and single hyphens only; 2–64 characters;
+- must match the regular expression `^[a-z0-9]+(?:-[a-z0-9]+)*$`;
+- describes the design, not you: `wallet-case`, `sticky-desk-stand`,
+  `fridge-magnet-mount`;
+- must be identical to the `id` field inside `printable.json`.
 
-## Step by step
+Anything else in the directory (extra photos, a `LICENSE` file) is allowed but
+ignored by the website. Do not add model files; pull requests that commit
+STL/3MF/STEP files will be asked to remove them.
 
-### 1. Publish the model
+## 4. printable.json field reference
 
-Upload the files to Printables, MakerWorld, Thingiverse, GrabCAD, GitHub, or
-your own site. Note the public page URL; it must start with `https://`.
+`printable.json` is a strict JSON object. Every key below is either required or
+optional; **any other key makes validation fail**. The formal definition is
+[`schemas/printable.schema.json`](../schemas/printable.schema.json).
 
-### 2. Copy the template
+### Top level
 
-From the repository root:
+| Field | Type | Required | Limits | What to write |
+|---|---|---|---|---|
+| `schemaVersion` | integer | Yes | must be `1` | Always `1` |
+| `id` | string | Yes | 2–64 chars, `^[a-z0-9]+(?:-[a-z0-9]+)*$` | Same as the directory name |
+| `name` | string | Yes | 1–80 chars | Card title, for example `Sticky Wallet Case` |
+| `category` | string | Yes | one of `case`, `stand`, `mount`, `accessory`, `reference` | Which filter shows the card; see [Section 5](#5-categories) |
+| `summary` | string | Yes | 1–140 chars | One sentence under the title. Say what it is and the one thing that makes it useful |
+| `description` | string | Yes | 1–800 chars | Two or three sentences: how it fits Sticky, recommended material, anything to know before printing |
+| `author` | object | Yes | see below | Who designed it |
+| `download` | object | Yes | see below | Where the files live |
+| `preview` | object | Yes | see below | The photo on the card |
+| `tags` | array of strings | No | up to 6 items, each 1–32 chars, no duplicates | Short labels shown beside the category, for example `snap-on`, `usb-c`, `tpu` |
 
-```bash
-cp -R printables/_template printables/my-case
-```
+### `author`
 
-Use a short lowercase name joined by hyphens, for example `sticky-desk-stand`
-or `wallet-case`. The directory name and the `id` inside `printable.json` must
-be identical.
+| Field | Type | Required | Limits | What to write |
+|---|---|---|---|---|
+| `author.name` | string | Yes | 1–80 chars | Person or team name shown on the card |
+| `author.url` | string | No | HTTPS URL, up to 2048 chars | Profile page opened when the name is selected: your Printables/MakerWorld profile, GitHub, or personal site |
 
-### 3. Fill in printable.json
+### `download`
+
+| Field | Type | Required | Limits | What to write |
+|---|---|---|---|---|
+| `download.platform` | string | Yes | 1–40 chars | Site that hosts the files. Becomes the button text **View on `<platform>`**. Use the site's own spelling: `Printables`, `MakerWorld`, `Thingiverse`, `GrabCAD`, `GitHub`, `Cults3D`, or your site name |
+| `download.url` | string | Yes | HTTPS URL, up to 2048 chars | The public page (or direct file link) where visitors download the model |
+| `download.license` | string | No | 1–80 chars | License shown on your download page, written the way the platform shows it: `CC BY 4.0`, `CC BY-SA 4.0`, `CC BY-NC 4.0`, `MIT`, `GPL-3.0` |
+
+### `preview`
+
+| Field | Type | Required | Limits | What to write |
+|---|---|---|---|---|
+| `preview.image` | string | Yes | must match `^assets/[A-Za-z0-9._-]+\.(png\|jpg\|jpeg\|webp)$`; file ≤ 5 MB | Path to the photo inside your directory, normally `assets/preview.jpg` |
+| `preview.alt` | string | Yes | 1–180 chars | One sentence describing the photo for screen readers and image search, for example `Black PETG wallet case fitted on reTerminal Sticky, front view` |
+
+### Complete example
 
 ```json
 {
@@ -62,8 +129,8 @@ be identical.
   "id": "my-case",
   "name": "My Case",
   "category": "case",
-  "summary": "A slim snap-on case that keeps the USB-C port open.",
-  "description": "My Case wraps the edges of reTerminal Sticky and leaves the screen, side button, and USB-C port uncovered. Print it in PETG for a firm fit or TPU for a softer bumper.",
+  "summary": "A slim snap-on case that keeps the USB-C port and side button open.",
+  "description": "My Case wraps the edges of reTerminal Sticky and leaves the screen, side button, and USB-C port uncovered. Print it in PETG for a firm fit or TPU for a softer bumper. The lip is 1.2 mm thick and clears the e-paper bezel.",
   "author": {
     "name": "Your name",
     "url": "https://www.printables.com/@your-profile"
@@ -77,54 +144,144 @@ be identical.
     "image": "assets/preview.jpg",
     "alt": "My Case printed in black PETG fitted on reTerminal Sticky"
   },
-  "tags": ["snap-on", "usb-c"]
+  "tags": ["snap-on", "usb-c", "petg"]
 }
 ```
 
-| Field | What to write |
+Writing tips:
+
+- `name`: title case, no trailing punctuation, no "for reTerminal Sticky" (every card is for Sticky).
+- `summary`: complete sentence with a period, no marketing adjectives.
+- `description`: mention fit, material, and any hardware the print needs (magnets, screws, felt pads).
+- Keep all text in English; the website serves a global audience.
+
+## 5. Categories
+
+`category` decides which filter on the left of the page shows your card. Pick
+the one that describes the primary purpose.
+
+| Value | Filter label | Use it for | Examples |
+|---|---|---|---|
+| `case` | Cases | Shells and bumpers that wrap the device itself | wallet case, snap-on bumper, full enclosure with lid |
+| `stand` | Stands | Anything that holds Sticky upright or at an angle on a surface | desk stand, charging stand, easel |
+| `mount` | Mounts | Parts that attach Sticky to something else | fridge magnet mount, wall bracket, monitor clip, bike clamp |
+| `accessory` | Accessories | Add-ons that are none of the above | stylus holder, cable clip, lanyard loop, travel box |
+| `reference` | Reference Models | Models of Sticky itself, used to design other parts | enclosure CAD model, dimension template, test-fit jig |
+
+If a design does two things (a case that is also a stand), choose the one a
+visitor would search for first and mention the other in `tags`.
+
+## 6. The preview photo
+
+The photo is the first thing visitors see, and the only way they can judge fit
+before opening your page.
+
+| Requirement | Details |
 |---|---|
-| `id` | Same as the directory name |
-| `name` | Title shown on the card |
-| `category` | One of the five categories below |
-| `summary` | One sentence shown under the title (up to 140 characters) |
-| `description` | Two or three sentences with fit, material, or usage notes (up to 800 characters) |
-| `author.name` | Your name or team; shown on the card |
-| `author.url` | Optional. Your profile page, opened when someone selects your name |
-| `download.platform` | Site that hosts the files, for example `Printables`, `MakerWorld`, `Thingiverse`, `GrabCAD`, `GitHub` |
-| `download.url` | Public page where the files are downloaded |
-| `download.license` | Optional. License shown on that page, for example `CC BY-SA 4.0` |
-| `preview.image` | Path to your photo inside `assets/`, for example `assets/preview.jpg` |
-| `preview.alt` | One sentence describing the photo for screen readers |
-| `tags` | Optional. Up to 6 short labels shown beside the category |
+| Real photo | The printed part fitted on a real reTerminal Sticky. Renders, slicer screenshots, and photos without the device are not accepted. |
+| Framing | Landscape, roughly 4:3. The card crops to that ratio, so keep the subject centred. |
+| Format | JPG, PNG, or WebP. JPG is usually smallest. |
+| Size | Up to 5 MB. 1200–1600 px on the long edge is plenty. |
+| Path | Inside `assets/`, referenced exactly in `preview.image`. |
+| Content | No watermarks, no text overlays, no other products. |
 
-### 4. Pick the category
+Good practice: natural light, plain background, the e-paper screen switched on
+and readable, one angle that shows how the print meets the device.
 
-| Category | Use it for | Example |
-|---|---|---|
-| `case` | Shells and bumpers that wrap the device | wallet case, snap-on bumper |
-| `stand` | Anything that holds Sticky upright or at an angle on a surface | desk stand, charging stand |
-| `mount` | Parts that attach Sticky to something else | fridge magnet mount, wall bracket, bike clamp |
-| `accessory` | Add-ons that are none of the above | stylus holder, cable clip, lanyard loop |
-| `reference` | Models of Sticky itself, used to design other parts | enclosure CAD model, dimension template |
+## 7. The README
 
-The category decides which filter shows your card on the website.
+The README is for people who already decided to print your design. Replace the
+template with these sections:
 
-### 5. Add the photo
+```markdown
+# My Case
 
-Save a real photo of the printed design fitted on reTerminal Sticky as
-`assets/preview.jpg` (PNG and WebP also work). Landscape framing at roughly 4:3
-looks best on the card. Keep the file under 5 MB.
+One paragraph: what it is, which part of Sticky it protects, holds, or mounts,
+and who it is for.
 
-### 6. Write the README
+## Print settings
 
-Replace the template README with:
+- Material: PETG (firm) or TPU 95A (soft)
+- Layer height: 0.2 mm
+- Walls: 3
+- Infill: 15 %
+- Supports: none
+- Orientation: back face on the bed
 
-- what the design is and which part of Sticky it protects, holds, or mounts;
-- print settings: material, layer height, supports, orientation;
-- assembly steps and how to remove the print again;
-- a link to the same download page.
+## Assembly
 
-### 7. Check locally
+1. Remove any brim.
+2. Slide the case on from the USB-C side first.
+3. Press the top edge until the lip clicks over the bezel.
+4. To remove, push the bottom corner out with a thumb.
+
+## Hardware
+
+None. (Or: 2 × 6 mm neodymium magnets, glued into the recesses.)
+
+## Files
+
+<https://www.printables.com/model/123456-my-case> — same page as `download.url`.
+
+## License
+
+CC BY-SA 4.0
+```
+
+Keep it short; anything longer belongs on your download page.
+
+## 8. Step by step
+
+### Step 1 — Publish the model
+
+Upload the files to Printables, MakerWorld, Thingiverse, GrabCAD, GitHub, or
+your own site. Copy the public page URL. It must start with `https://`, and
+opening it in a private browser window must show the files without logging in.
+
+### Step 2 — Take the photo
+
+Print the design, fit it on your Sticky, and take the photo described in
+[Section 6](#6-the-preview-photo). Save it as `preview.jpg`.
+
+### Step 3 — Get a copy of the repository
+
+Choose one of the three methods in
+[CONTRIBUTING.md → Three ways to submit](../CONTRIBUTING.md#5-three-ways-to-submit):
+
+- **Method A** (git): fork, clone, create a branch.
+- **Method B** (web): fork, then create files directly in the GitHub interface.
+
+The rest of this section assumes Method A; the file contents are identical for
+Method B.
+
+### Step 4 — Copy the template
+
+From the repository root:
+
+```bash
+cp -R printables/_template printables/my-case
+```
+
+You now have `printables/my-case/printable.json`, `README.md`, and
+`assets/README.md`.
+
+### Step 5 — Fill in printable.json
+
+Open `printables/my-case/printable.json` and replace every value, following
+[Section 4](#4-printablejson-field-reference). Change `id` to `my-case`.
+
+### Step 6 — Add the photo
+
+Copy your photo to `printables/my-case/assets/preview.jpg` and delete
+`assets/README.md` (it only explained what to put there). Make sure
+`preview.image` in `printable.json` is `assets/preview.jpg`.
+
+### Step 7 — Write the README
+
+Replace `printables/my-case/README.md` with the outline from
+[Section 7](#7-the-readme).
+
+### Step 8 — Check locally
 
 Install Node.js 20 or newer, then run from the repository root:
 
@@ -133,32 +290,134 @@ npm test
 npm run validate
 ```
 
-`npm run validate` confirms that the directory name and `id` match, every
-required field is present, the download URL uses HTTPS, the category is one of
-the five values, and the photo exists in the right format. It prints
-`Registry validation passed` when everything is in place.
+Expected last line:
 
-### 8. Open the pull request
+```text
+Registry validation passed (12 firmware(s), 6 printable(s)).
+```
 
-Select **3D printable design** in the pull request template and complete its
-short checklist. A maintainer confirms the author credit, the download page,
-and the photo, then merges the PR. The card appears on the Sticky website with
-the next site release; see [CONTRIBUTING.md](../CONTRIBUTING.md#after-your-pull-request-is-merged).
+(The numbers count every directory in the repository, so the printable count
+goes up by one with your design.) If it fails, see
+[Section 9](#9-validation-errors-and-how-to-fix-them).
 
-## Updating a design
+### Step 9 — Commit and push
 
-Edit the files in your directory and open a new pull request. Common updates:
+```bash
+git add printables/my-case
+git commit -m "feat: add My Case printable"
+git push -u origin add-my-case
+```
 
-- a new download URL after moving to another platform;
-- a better photo;
-- a changed category or description.
+### Step 10 — Open the pull request
 
-## Checklist
+On GitHub, open the pull request from your branch to
+`Seeed-Projects/reterminal-sticky-playground-registry` / `main`. In the
+template:
 
-- [ ] The directory name and `printable.json` `id` are identical.
+- under **Contribution type**, tick **3D printable design: new design or update**;
+- complete **Common verification**;
+- complete the **3D printable design** section: design name, directory,
+  download page, platform, category, and the five checkboxes;
+- leave the **Firmware** section untouched.
+
+Title suggestion: `Add <Design Name> printable`.
+
+### Step 11 — Review
+
+GitHub Actions runs `npm test` and `npm run validate` within a couple of
+minutes. A maintainer then checks the author credit, the download page, and the
+photo. Reply to comments on the PR or push fixes to the same branch. After
+merge, the card appears with the next Sticky website release; see
+[CONTRIBUTING.md → After your pull request is merged](../CONTRIBUTING.md#9-after-your-pull-request-is-merged).
+
+## 9. Validation errors and how to fix them
+
+Every error names the file, then the field path, then the problem. Examples
+for `printables/my-case/printable.json`:
+
+| Error text | Cause | Fix |
+|---|---|---|
+| `printables/my-case: is missing printable.json` | File not created, or named differently | Create `printables/my-case/printable.json` |
+| `...printable.json: contains invalid JSON (...)` | Missing comma, trailing comma, or unquoted key | Paste the file into a JSON checker; fix the reported line |
+| `...printable.json: missing required field "download"` | A required top-level object is absent | Add the object from [Section 4](#4-printablejson-field-reference) |
+| `...printable.json: contains unsupported field "mode"` | A key that is not in the field reference | Remove it (firmware-only fields such as `mode`, `catalogSection`, `source`, `external` do not belong here) |
+| `...printable.json.id: must match the directory name "my-case"` | `id` differs from the directory | Make them identical |
+| `...printable.json.category: must be one of: case, stand, mount, accessory, reference` | Typo or a firmware category | Use one of the five values |
+| `...printable.json.summary: must contain between 1 and 140 characters` | Too long | Shorten to one sentence; move detail to `description` |
+| `...printable.json.download.url: must use HTTPS` | URL starts with `http://` | Use the `https://` version of the page |
+| `...printable.json.download.url: must be a valid absolute URL` | Missing scheme or spaces | Copy the URL from the browser address bar |
+| `...printable.json.preview.image: must be inside the assets/ directory` | Path does not start with `assets/` | Move the file and write `assets/preview.jpg` |
+| `...printable.json.preview.image: references a missing file: assets/preview.jpg` | File name or extension differs, or the file was not added to git | Check spelling and case; run `git add printables/my-case/assets` |
+| `...printable.json.preview.image: must use one of these file extensions: .png, .jpg, .jpeg, .webp` | HEIC, SVG, GIF, or other format | Export as JPG or PNG |
+| `...printable.json.preview.image: does not contain a valid JPEG file signature` | A PNG (or other file) renamed to `.jpg` | Re-export in the right format, or rename to the real extension and update `preview.image` |
+| `...printable.json.preview.image: must not exceed 5 MB` | Photo too large | Resize to about 1600 px on the long edge |
+| `...printable.json.tags: must be an array containing no more than 6 tags` | Too many tags | Keep the six most useful |
+| `...printable.json.tags[2]: duplicates tag "case"` | Same tag twice | Remove the duplicate |
+| `...printable.json.README.md: references a missing file: README.md` | README deleted or not committed | Add `printables/my-case/README.md` |
+
+## 10. Updating a design
+
+Edit the files in your directory and open a new pull request (Method A, B, or
+C in CONTRIBUTING.md). Tick **3D printable design: new design or update** in
+the template and say what changed. Typical updates:
+
+| Change | What to edit |
+|---|---|
+| Moved to another platform | `download.platform`, `download.url`, README link |
+| Better photo | Replace `assets/preview.jpg`; update `preview.alt` if the view changed |
+| New revision of the model | `description` (mention the revision), README print settings |
+| Different license | `download.license`, README |
+| Re-categorise | `category` |
+
+The directory name and `id` stay the same so the card keeps its identity.
+
+## 11. Worked example
+
+The Sticky Wallet Case by Dropthetenors is published on Thingiverse. Its card
+in this repository is:
+
+`printables/sticky-wallet-case/printable.json`
+
+```json
+{
+  "schemaVersion": 1,
+  "id": "sticky-wallet-case",
+  "name": "Sticky Wallet Case",
+  "category": "case",
+  "summary": "A slim printed wallet-style case designed around the Sticky card form factor.",
+  "description": "A slim wallet-style case that wraps around reTerminal Sticky so it can be carried like a card. Files are published on Thingiverse.",
+  "author": {
+    "name": "Dropthetenors",
+    "url": "https://www.thingiverse.com/thing:7396154"
+  },
+  "download": {
+    "platform": "Thingiverse",
+    "url": "https://www.thingiverse.com/thing:7396154/files"
+  },
+  "preview": {
+    "image": "assets/preview.jpg",
+    "alt": "Sticky Wallet Case printed and fitted on reTerminal Sticky"
+  },
+  "tags": [
+    "case"
+  ]
+}
+```
+
+On the website this renders as a card under **Cases** with the title
+"Sticky Wallet Case", the author "Dropthetenors" linked to the Thingiverse page,
+and a **View on Thingiverse** button that opens the files tab. Browse the other
+directories under `printables/` for more real examples.
+
+## 12. Checklist
+
+- [ ] The directory name and `printable.json` `id` are identical and use only lowercase letters, digits, and hyphens.
 - [ ] `category` is one of `case`, `stand`, `mount`, `accessory`, `reference`.
-- [ ] `download.url` is the public HTTPS page that hosts the files.
-- [ ] `author.name` credits the designer; `download.license` matches the download page when a license is shown.
-- [ ] `assets/preview.jpg` is a real photo of the print on reTerminal Sticky.
-- [ ] The README lists print settings and assembly notes.
+- [ ] `summary` is one sentence (≤ 140 characters); `description` is two or three sentences (≤ 800).
+- [ ] `author.name` credits the designer; `author.url` (if given) is HTTPS.
+- [ ] `download.platform` is the hosting site's name; `download.url` is the public HTTPS page; `download.license` matches the page when a license is shown.
+- [ ] `assets/preview.jpg` is a real photo of the print on reTerminal Sticky, ≤ 5 MB, referenced exactly in `preview.image`, with a descriptive `preview.alt`.
+- [ ] `README.md` lists print settings, assembly steps, hardware, files link, and license.
+- [ ] No model files are committed.
 - [ ] `npm test` and `npm run validate` pass.
+- [ ] The PR template has **3D printable design** ticked and its section completed.

--- a/docs/contributing-printables.zh-CN.md
+++ b/docs/contributing-printables.zh-CN.md
@@ -1,60 +1,123 @@
 # 贡献 3D 打印设计
 
-本指南面向 Sticky Playground **3D Printables** 页面的外壳、支架、安装件和配件贡献，
-写给在 Printables、MakerWorld、Thingiverse、GrabCAD 或 GitHub 上发布模型的创客。
-你不需要了解任何固件知识。
+本指南面向 Sticky Playground [**3D Printables**](https://www.seeedstudio.com/sticky/playground/3d-printables/)
+页面的外壳、支架、安装件和配件贡献，写给在 Printables、MakerWorld、Thingiverse、
+GrabCAD 或 GitHub 上发布模型的创客。你不需要了解任何固件或 ESP-IDF 知识。
 
 英文指南请查看 [contributing-printables.md](contributing-printables.md)。
-两类贡献共用的审核与发布流程见 [CONTRIBUTING.zh-CN.md](../CONTRIBUTING.zh-CN.md)。
+与固件贡献共用的规则、三种提交 PR 的方式以及发布流程，见
+[CONTRIBUTING.zh-CN.md](../CONTRIBUTING.zh-CN.md)。
 
-## 你需要提交什么
+## 目录
 
-你提交的是一张「卡片」，不是模型文件：
+1. [你需要提交什么](#1-你需要提交什么)
+2. [访客会看到什么](#2-访客会看到什么)
+3. [目录里的文件](#3-目录里的文件)
+4. [printable.json 字段说明](#4-printablejson-字段说明)
+5. [分类](#5-分类)
+6. [预览照片](#6-预览照片)
+7. [README](#7-readme)
+8. [分步操作](#8-分步操作)
+9. [校验报错与修法](#9-校验报错与修法)
+10. [更新已有设计](#10-更新已有设计)
+11. [真实示例](#11-真实示例)
+12. [提交前清单](#12-提交前清单)
 
-- 一个很小的 `printable.json`，写卡片上显示的文字；
-- 一张打印成品装在真机 reTerminal Sticky 上的照片；
-- 一份简短的 README，写打印参数和组装说明。
+## 1. 你需要提交什么
 
-模型文件继续留在你自己的下载页。Sticky 网站展示你的卡片，并通过 **View on …**
-按钮把访客送到你的页面。
+你提交的是一张**卡片**，不是模型文件：
 
-```text
-printables/
-  my-case/
-    printable.json
-    README.md
-    assets/
-      preview.jpg
-```
+| 文件 | 作用 | 必需 |
+|---|---|---|
+| `printables/<design-id>/printable.json` | 卡片上显示的文字和链接 | 是 |
+| `printables/<design-id>/assets/preview.jpg` | 打印成品装在真机 reTerminal Sticky 上的照片 | 是 |
+| `printables/<design-id>/README.md` | 打印参数、组装说明，以及下载链接 | 是 |
+
+STL / 3MF / STEP 文件留在你自己的下载页。Sticky 网站展示你的卡片，并通过
+**View on …** 按钮把访客送到那个页面。文件的控制权始终在你手里：更新文件、增加
+remix、更换许可证都不需要再到这里提 PR。
 
 一句话总结：你交一张名片和一张照片，文件放在你自己那里。
 
-## 访客会看到什么
+## 2. 访客会看到什么
 
-1. 访客打开 Sticky Playground，切到 **3D Printables**。
-2. 访客按分类筛选，点开你的卡片。
-3. 访客点击 **View on Printables**（或你填写的平台名）。
-4. 访客在你的页面下载文件。
+3D Printables 页面上，每个设计是网格里的一张卡片，左侧有分类筛选。一张卡片从上到下是：
 
-## 分步操作
+1. 你的 `preview.image` 照片（裁成约 4:3）；
+2. 分类标签（例如 **Cases**）和 `tags` 里的标签；
+3. `name` 作为标题；
+4. `summary` 显示在标题下方一到两行；
+5. 一行 **Author**，显示 `author.name`，如果填了 `author.url` 会带链接；
+6. 一个通栏按钮 **View on `<download.platform>`**，在新标签页打开 `download.url`。
 
-### 1. 先发布模型
+`description` 会保存下来用于详情和搜索，目前不在网格里显示，所以最关键的信息要写在
+`summary` 里。
 
-把文件上传到 Printables、MakerWorld、Thingiverse、GrabCAD、GitHub 或你自己的网站，
-记下公开页面的地址；地址必须以 `https://` 开头。
+## 3. 目录里的文件
 
-### 2. 复制模板
-
-在仓库根目录执行：
-
-```bash
-cp -R printables/_template printables/my-case
+```text
+printables/
+  my-case/                 <- 目录名 = id
+    printable.json         <- 卡片元数据（本指南第 4 节）
+    README.md              <- 打印参数和组装说明（第 7 节）
+    assets/
+      preview.jpg          <- preview.image 引用的照片（第 6 节）
 ```
 
-目录名用小写英文加连字符，例如 `sticky-desk-stand`、`wallet-case`。目录名必须和
-`printable.json` 里的 `id` 完全一致。
+目录名（`<design-id>`）的规则：
 
-### 3. 填写 printable.json
+- 只用小写字母、数字和单个连字符，2–64 个字符；
+- 必须匹配正则 `^[a-z0-9]+(?:-[a-z0-9]+)*$`；
+- 描述设计本身而不是你：`wallet-case`、`sticky-desk-stand`、`fridge-magnet-mount`；
+- 必须与 `printable.json` 里的 `id` 完全一致。
+
+目录里放其他东西（额外照片、`LICENSE` 文件）是允许的，网站会忽略。请不要放模型文件；
+提交了 STL/3MF/STEP 的 PR 会被要求删掉。
+
+## 4. printable.json 字段说明
+
+`printable.json` 是一个严格的 JSON 对象。下面每个键要么必填要么可选；
+**出现任何其他键都会导致校验失败**。正式定义见
+[`schemas/printable.schema.json`](../schemas/printable.schema.json)。
+
+### 顶层字段
+
+| 字段 | 类型 | 必填 | 限制 | 填什么 |
+|---|---|---|---|---|
+| `schemaVersion` | 整数 | 是 | 必须是 `1` | 固定写 `1` |
+| `id` | 字符串 | 是 | 2–64 字符，`^[a-z0-9]+(?:-[a-z0-9]+)*$` | 与目录名相同 |
+| `name` | 字符串 | 是 | 1–80 字符 | 卡片标题，例如 `Sticky Wallet Case` |
+| `category` | 字符串 | 是 | `case`、`stand`、`mount`、`accessory`、`reference` 之一 | 决定卡片出现在哪个筛选项下，见[第 5 节](#5-分类) |
+| `summary` | 字符串 | 是 | 1–140 字符 | 标题下的一句话：它是什么、最有用的一点是什么 |
+| `description` | 字符串 | 是 | 1–800 字符 | 两三句话：如何贴合 Sticky、推荐材料、打印前要知道的事 |
+| `author` | 对象 | 是 | 见下 | 设计者 |
+| `download` | 对象 | 是 | 见下 | 文件在哪里 |
+| `preview` | 对象 | 是 | 见下 | 卡片上的照片 |
+| `tags` | 字符串数组 | 否 | 最多 6 项，每项 1–32 字符，不重复 | 显示在分类旁的短标签，例如 `snap-on`、`usb-c`、`tpu` |
+
+### `author`
+
+| 字段 | 类型 | 必填 | 限制 | 填什么 |
+|---|---|---|---|---|
+| `author.name` | 字符串 | 是 | 1–80 字符 | 显示在卡片上的个人或团队名 |
+| `author.url` | 字符串 | 否 | HTTPS 网址，最长 2048 | 点击名字时打开的主页：Printables/MakerWorld 个人页、GitHub 或个人网站 |
+
+### `download`
+
+| 字段 | 类型 | 必填 | 限制 | 填什么 |
+|---|---|---|---|---|
+| `download.platform` | 字符串 | 是 | 1–40 字符 | 托管文件的网站名，会变成按钮文字 **View on `<platform>`**。按网站自己的写法：`Printables`、`MakerWorld`、`Thingiverse`、`GrabCAD`、`GitHub`、`Cults3D`，或你自己的站名 |
+| `download.url` | 字符串 | 是 | HTTPS 网址，最长 2048 | 访客下载模型的公开页面（或直接的文件链接） |
+| `download.license` | 字符串 | 否 | 1–80 字符 | 下载页标注的许可证，按平台的写法：`CC BY 4.0`、`CC BY-SA 4.0`、`CC BY-NC 4.0`、`MIT`、`GPL-3.0` |
+
+### `preview`
+
+| 字段 | 类型 | 必填 | 限制 | 填什么 |
+|---|---|---|---|---|
+| `preview.image` | 字符串 | 是 | 必须匹配 `^assets/[A-Za-z0-9._-]+\.(png\|jpg\|jpeg\|webp)$`；文件 ≤ 5 MB | 照片在目录内的路径，通常是 `assets/preview.jpg` |
+| `preview.alt` | 字符串 | 是 | 1–180 字符 | 一句话描述照片内容，供读屏软件和图片搜索使用，例如 `Black PETG wallet case fitted on reTerminal Sticky, front view` |
+
+### 完整示例
 
 ```json
 {
@@ -62,8 +125,8 @@ cp -R printables/_template printables/my-case
   "id": "my-case",
   "name": "My Case",
   "category": "case",
-  "summary": "A slim snap-on case that keeps the USB-C port open.",
-  "description": "My Case wraps the edges of reTerminal Sticky and leaves the screen, side button, and USB-C port uncovered. Print it in PETG for a firm fit or TPU for a softer bumper.",
+  "summary": "A slim snap-on case that keeps the USB-C port and side button open.",
+  "description": "My Case wraps the edges of reTerminal Sticky and leaves the screen, side button, and USB-C port uncovered. Print it in PETG for a firm fit or TPU for a softer bumper. The lip is 1.2 mm thick and clears the e-paper bezel.",
   "author": {
     "name": "Your name",
     "url": "https://www.printables.com/@your-profile"
@@ -77,55 +140,132 @@ cp -R printables/_template printables/my-case
     "image": "assets/preview.jpg",
     "alt": "My Case printed in black PETG fitted on reTerminal Sticky"
   },
-  "tags": ["snap-on", "usb-c"]
+  "tags": ["snap-on", "usb-c", "petg"]
 }
 ```
 
-| 字段 | 填什么 |
+写作建议：
+
+- `name`：首字母大写的标题，结尾不加标点，不用写 "for reTerminal Sticky"（每张卡都是给 Sticky 的）。
+- `summary`：一个完整句子，句号结尾，不堆形容词。
+- `description`：说明贴合方式、材料，以及需要的五金件（磁铁、螺丝、毛毡垫）。
+- 所有文字使用英文，网站面向全球访客。
+
+## 5. 分类
+
+`category` 决定你的卡片出现在页面左侧哪个筛选项下。按设计的主要用途选一个。
+
+| 值 | 筛选项名称 | 适用范围 | 例子 |
+|---|---|---|---|
+| `case` | Cases | 包裹设备本体的外壳和保护套 | 钱包式外壳、卡扣式保护套、带盖全包外壳 |
+| `stand` | Stands | 让 Sticky 立在桌面或斜放的支架 | 桌面支架、充电支架、画架式支架 |
+| `mount` | Mounts | 把 Sticky 固定到其他物体上的部件 | 冰箱磁吸座、墙面支架、显示器夹、车把夹 |
+| `accessory` | Accessories | 以上都不属于的附加件 | 触控笔座、线夹、挂绳环、收纳盒 |
+| `reference` | Reference Models | Sticky 本体的模型，用于设计其他部件 | 外壳 CAD 模型、尺寸模板、试装夹具 |
+
+一个设计兼具两种用途（既是外壳又是支架）时，选访客最可能先搜的那个，另一个写进 `tags`。
+
+## 6. 预览照片
+
+照片是访客第一眼看到的东西，也是他们打开你页面前判断贴合度的唯一依据。
+
+| 要求 | 说明 |
 |---|---|
-| `id` | 与目录名相同 |
-| `name` | 卡片标题 |
-| `category` | 下方五个分类之一 |
-| `summary` | 标题下方的一句话（不超过 140 字符） |
-| `description` | 两三句话，说明贴合度、材料或使用注意（不超过 800 字符） |
-| `author.name` | 你的名字或团队名，显示在卡片上 |
-| `author.url` | 可选。你的主页，点击名字时打开 |
-| `download.platform` | 托管文件的网站名，例如 `Printables`、`MakerWorld`、`Thingiverse`、`GrabCAD`、`GitHub` |
-| `download.url` | 下载文件的公开页面 |
-| `download.license` | 可选。该页面标注的许可证，例如 `CC BY-SA 4.0` |
-| `preview.image` | 照片在 `assets/` 内的路径，例如 `assets/preview.jpg` |
-| `preview.alt` | 一句话描述照片内容，供读屏软件使用 |
-| `tags` | 可选。最多 6 个短标签，显示在分类旁边 |
+| 真实照片 | 打印成品装在真机 reTerminal Sticky 上。渲染图、切片软件截图、没有设备的照片都不接受。 |
+| 构图 | 横向，约 4:3。卡片会按这个比例裁切，主体放在中间。 |
+| 格式 | JPG、PNG 或 WebP。JPG 通常最小。 |
+| 大小 | 最大 5 MB。长边 1200–1600 px 足够。 |
+| 路径 | 放在 `assets/` 下，与 `preview.image` 完全一致。 |
+| 内容 | 不加水印、不叠文字、不出现其他产品。 |
 
-卡片上的文字面向全球访客，请使用英文填写。
+好的做法：自然光、纯色背景、墨水屏亮着且内容可读、一个能看出打印件与设备如何贴合的角度。
 
-### 4. 选择分类
+## 7. README
 
-| 分类 | 适用范围 | 例子 |
-|---|---|---|
-| `case` | 包裹设备的外壳和保护套 | 钱包式外壳、卡扣式保护套 |
-| `stand` | 让 Sticky 立在桌面或斜放的支架 | 桌面支架、充电支架 |
-| `mount` | 把 Sticky 固定到其他物体上的部件 | 冰箱磁吸座、墙面支架、车把夹 |
-| `accessory` | 以上都不属于的附加件 | 触控笔座、线夹、挂绳环 |
-| `reference` | Sticky 本体的模型，用于设计其他部件 | 外壳 CAD 模型、尺寸模板 |
+README 是给已经决定打印你设计的人看的。把模板替换成下面这些小节：
 
-分类决定你的卡片出现在网站左侧哪个筛选项下。
+```markdown
+# My Case
 
-### 5. 放入照片
+One paragraph: what it is, which part of Sticky it protects, holds, or mounts,
+and who it is for.
 
-把打印成品装在 reTerminal Sticky 上的真实照片保存为 `assets/preview.jpg`
-（PNG、WebP 也可以）。横向、约 4:3 的构图在卡片上效果最好。文件不超过 5 MB。
+## Print settings
 
-### 6. 写 README
+- Material: PETG (firm) or TPU 95A (soft)
+- Layer height: 0.2 mm
+- Walls: 3
+- Infill: 15 %
+- Supports: none
+- Orientation: back face on the bed
 
-用下面的内容替换模板 README：
+## Assembly
 
-- 这个设计是什么，保护、支撑或固定 Sticky 的哪个部位；
-- 打印参数：材料、层高、支撑、摆放方向；
-- 组装步骤，以及如何再取下来；
-- 与 `printable.json` 相同的下载页链接。
+1. Remove any brim.
+2. Slide the case on from the USB-C side first.
+3. Press the top edge until the lip clicks over the bezel.
+4. To remove, push the bottom corner out with a thumb.
 
-### 7. 本地自检
+## Hardware
+
+None. (Or: 2 × 6 mm neodymium magnets, glued into the recesses.)
+
+## Files
+
+<https://www.printables.com/model/123456-my-case> — same page as `download.url`.
+
+## License
+
+CC BY-SA 4.0
+```
+
+保持简短；更长的内容放在你的下载页。README 同样使用英文。
+
+## 8. 分步操作
+
+### 第 1 步 —— 先发布模型
+
+把文件上传到 Printables、MakerWorld、Thingiverse、GrabCAD、GitHub 或你自己的网站，
+复制公开页面的地址。地址必须以 `https://` 开头，并且在浏览器隐私窗口里不登录也能看到文件。
+
+### 第 2 步 —— 拍照
+
+打印出来装在你的 Sticky 上，按[第 6 节](#6-预览照片)拍照，保存为 `preview.jpg`。
+
+### 第 3 步 —— 拿到仓库副本
+
+从 [CONTRIBUTING.zh-CN.md → 三种提交方式](../CONTRIBUTING.zh-CN.md#5-三种提交方式) 里选一种：
+
+- **方式 A**（git）：Fork、克隆、新建分支。
+- **方式 B**（网页）：Fork 后直接在 GitHub 网页里创建文件。
+
+下面按方式 A 讲；方式 B 需要创建的文件内容完全相同。
+
+### 第 4 步 —— 复制模板
+
+在仓库根目录执行：
+
+```bash
+cp -R printables/_template printables/my-case
+```
+
+现在你有了 `printables/my-case/printable.json`、`README.md` 和 `assets/README.md`。
+
+### 第 5 步 —— 填写 printable.json
+
+打开 `printables/my-case/printable.json`，按[第 4 节](#4-printablejson-字段说明)替换每一个值。
+把 `id` 改成 `my-case`。
+
+### 第 6 步 —— 放入照片
+
+把照片复制到 `printables/my-case/assets/preview.jpg`，删掉 `assets/README.md`
+（它只是说明这里该放什么）。确认 `printable.json` 里的 `preview.image` 是 `assets/preview.jpg`。
+
+### 第 7 步 —— 写 README
+
+用[第 7 节](#7-readme)的结构替换 `printables/my-case/README.md`。
+
+### 第 8 步 —— 本地自检
 
 安装 Node.js 20 或更高版本，在仓库根目录执行：
 
@@ -134,30 +274,128 @@ npm test
 npm run validate
 ```
 
-`npm run validate` 会确认目录名与 `id` 一致、必填字段齐全、下载地址使用 HTTPS、
-分类在五个值之内、照片存在且格式正确。全部通过时会打印
-`Registry validation passed`。
+预期最后一行：
 
-### 8. 提交 pull request
+```text
+Registry validation passed (12 firmware(s), 6 printable(s)).
+```
 
-在 PR 模板中勾选 **3D printable design**，完成对应的简短清单。维护者核对署名、
-下载页和照片后合并。卡片会随下一次网站发布出现在 Sticky 官网，
-见 [CONTRIBUTING.zh-CN.md](../CONTRIBUTING.zh-CN.md#pr-合并之后)。
+（数字是仓库里全部目录的数量，加上你的设计后打印件会多 1。）失败请看
+[第 9 节](#9-校验报错与修法)。
 
-## 更新已有设计
+### 第 9 步 —— 提交并推送
 
-直接修改你目录下的文件，再提交一个新的 pull request。常见更新：
+```bash
+git add printables/my-case
+git commit -m "feat: add My Case printable"
+git push -u origin add-my-case
+```
 
-- 换了平台后的新下载地址；
-- 更好的照片；
-- 调整分类或描述。
+### 第 10 步 —— 提交 pull request
 
-## 提交前清单
+在 GitHub 上从你的分支向 `Seeed-Projects/reterminal-sticky-playground-registry` 的
+`main` 发起 pull request。在模板里：
 
-- [ ] 目录名与 `printable.json` 的 `id` 完全一致。
+- **Contribution type** 勾选 **3D printable design: new design or update**；
+- 完成 **Common verification**；
+- 完成 **3D printable design** 一节：设计名、目录、下载页、平台、分类和五个勾选项；
+- **Firmware** 一节保持不动。
+
+标题建议：`Add <Design Name> printable`。
+
+### 第 11 步 —— 审核
+
+GitHub Actions 会在几分钟内运行 `npm test` 和 `npm run validate`。之后维护者核对署名、
+下载页和照片。在 PR 里回复评论，或直接往同一分支推送修改。合并后，卡片会随下一次
+Sticky 网站发布上线，见
+[CONTRIBUTING.zh-CN.md → PR 合并之后](../CONTRIBUTING.zh-CN.md#9-pr-合并之后)。
+
+一句话总结：发布模型 → 拍照 → 复制模板填三份文件 → 本地校验 → 提 PR。
+
+## 9. 校验报错与修法
+
+每条报错依次是：文件、字段路径、问题。以 `printables/my-case/printable.json` 为例：
+
+| 报错文字 | 原因 | 修法 |
+|---|---|---|
+| `printables/my-case: is missing printable.json` | 文件没创建，或名字不对 | 创建 `printables/my-case/printable.json` |
+| `...printable.json: contains invalid JSON (...)` | 少逗号、多逗号、键没加引号 | 把文件贴进 JSON 检查工具，修正提示的那一行 |
+| `...printable.json: missing required field "download"` | 缺少必填的顶层对象 | 按[第 4 节](#4-printablejson-字段说明)补上 |
+| `...printable.json: contains unsupported field "mode"` | 出现了字段说明里没有的键 | 删掉它（`mode`、`catalogSection`、`source`、`external` 这类固件字段不属于这里） |
+| `...printable.json.id: must match the directory name "my-case"` | `id` 与目录名不一致 | 改成一样 |
+| `...printable.json.category: must be one of: case, stand, mount, accessory, reference` | 拼错，或填了固件分类 | 用五个值之一 |
+| `...printable.json.summary: must contain between 1 and 140 characters` | 太长 | 缩成一句话，细节移到 `description` |
+| `...printable.json.download.url: must use HTTPS` | 以 `http://` 开头 | 换成 `https://` 版本 |
+| `...printable.json.download.url: must be a valid absolute URL` | 缺协议头或含空格 | 从浏览器地址栏完整复制 |
+| `...printable.json.preview.image: must be inside the assets/ directory` | 路径不以 `assets/` 开头 | 移动文件并写成 `assets/preview.jpg` |
+| `...printable.json.preview.image: references a missing file: assets/preview.jpg` | 文件名或后缀不一致，或没加进 git | 检查拼写和大小写；执行 `git add printables/my-case/assets` |
+| `...printable.json.preview.image: must use one of these file extensions: .png, .jpg, .jpeg, .webp` | HEIC、SVG、GIF 等格式 | 导出为 JPG 或 PNG |
+| `...printable.json.preview.image: does not contain a valid JPEG file signature` | 把 PNG（或别的文件）直接改名成 `.jpg` | 用正确格式重新导出，或改回真实后缀并更新 `preview.image` |
+| `...printable.json.preview.image: must not exceed 5 MB` | 照片过大 | 缩到长边约 1600 px |
+| `...printable.json.tags: must be an array containing no more than 6 tags` | 标签太多 | 保留最有用的 6 个 |
+| `...printable.json.tags[2]: duplicates tag "case"` | 同一标签出现两次 | 删掉重复项 |
+| `...printable.json.README.md: references a missing file: README.md` | README 被删或没提交 | 加上 `printables/my-case/README.md` |
+
+## 10. 更新已有设计
+
+修改你目录下的文件，再提一个新的 pull request（CONTRIBUTING 里的方式 A、B 或 C 均可）。
+模板里勾选 **3D printable design: new design or update**，并说明改了什么。常见更新：
+
+| 变化 | 改哪里 |
+|---|---|
+| 换到别的平台 | `download.platform`、`download.url`、README 里的链接 |
+| 更好的照片 | 替换 `assets/preview.jpg`；视角变了就更新 `preview.alt` |
+| 模型出了新版本 | `description`（提一下版本）、README 的打印参数 |
+| 更换许可证 | `download.license`、README |
+| 重新分类 | `category` |
+
+目录名和 `id` 保持不变，卡片才能保留身份。
+
+## 11. 真实示例
+
+Dropthetenors 的 Sticky Wallet Case 发布在 Thingiverse。它在本仓库里的卡片是：
+
+`printables/sticky-wallet-case/printable.json`
+
+```json
+{
+  "schemaVersion": 1,
+  "id": "sticky-wallet-case",
+  "name": "Sticky Wallet Case",
+  "category": "case",
+  "summary": "A slim printed wallet-style case designed around the Sticky card form factor.",
+  "description": "A slim wallet-style case that wraps around reTerminal Sticky so it can be carried like a card. Files are published on Thingiverse.",
+  "author": {
+    "name": "Dropthetenors",
+    "url": "https://www.thingiverse.com/thing:7396154"
+  },
+  "download": {
+    "platform": "Thingiverse",
+    "url": "https://www.thingiverse.com/thing:7396154/files"
+  },
+  "preview": {
+    "image": "assets/preview.jpg",
+    "alt": "Sticky Wallet Case printed and fitted on reTerminal Sticky"
+  },
+  "tags": [
+    "case"
+  ]
+}
+```
+
+在网站上，它显示为 **Cases** 分类下一张标题为 "Sticky Wallet Case" 的卡片，作者
+"Dropthetenors" 链接到 Thingiverse 页面，按钮 **View on Thingiverse** 打开文件标签页。
+`printables/` 下的其他目录都是真实示例，可以随时参考。
+
+## 12. 提交前清单
+
+- [ ] 目录名与 `printable.json` 的 `id` 完全一致，只含小写字母、数字和连字符。
 - [ ] `category` 是 `case`、`stand`、`mount`、`accessory`、`reference` 之一。
-- [ ] `download.url` 是托管文件的公开 HTTPS 页面。
-- [ ] `author.name` 写明设计者；下载页标注了许可证时，`download.license` 与之一致。
-- [ ] `assets/preview.jpg` 是打印成品装在 reTerminal Sticky 上的真实照片。
-- [ ] README 写明打印参数和组装说明。
+- [ ] `summary` 是一句话（≤ 140 字符）；`description` 两三句话（≤ 800）。
+- [ ] `author.name` 写明设计者；`author.url`（如有）是 HTTPS。
+- [ ] `download.platform` 是托管网站名；`download.url` 是公开 HTTPS 页面；下载页标注了许可证时 `download.license` 与之一致。
+- [ ] `assets/preview.jpg` 是打印成品装在 reTerminal Sticky 上的真实照片，≤ 5 MB，与 `preview.image` 完全一致，并有描述性的 `preview.alt`。
+- [ ] `README.md` 写明打印参数、组装步骤、五金件、文件链接和许可证。
+- [ ] 没有提交任何模型文件。
 - [ ] `npm test` 和 `npm run validate` 通过。
+- [ ] PR 模板勾选了 **3D printable design** 并完成了对应小节。


### PR DESCRIPTION
## Summary

- `CONTRIBUTING.md` / `.zh-CN.md`: prerequisites table, annotated repository layout, how a contribution reaches the website, three submission methods with exact steps (git fork/clone, GitHub web upload without git, in-browser edit for updates), shared rules table, how to read `npm run validate` output, review timeline, post-merge release flow, update/remove/transfer, FAQ.
- `docs/contributing-printables.md` / `.zh-CN.md`: what visitors see on the card, directory rules, complete `printable.json` field reference (type / required / limits / what to write) for every field and sub-object, category table with examples, photo requirements, README outline, 11-step walkthrough, validation-error table with fixes, update table, worked example from `printables/sticky-wallet-case`, checklist.
- `docs/contributing-firmware.md` / `.zh-CN.md`: table of contents, complete `firmware.json` field reference grouped by purpose (identity, attribution, compatibility, build, versions) with the community category table, `manifest.json` reference for firmware-only packages including how to compute size and SHA-256, common validation errors table, and a "Submitting the pull request" section covering the PR template and the CI build artifact.

## Test plan

- [x] `npm test` (34) and `npm run validate` pass; no non-doc files changed
- [x] All relative links and heading anchors across the six guides resolve (checked with a script)
- [x] Error messages in the troubleshooting tables reproduced against the validator