### PR TITLE
ci: build only the firmwares a pull request touches

### DIFF
--- a/.github/workflows/validate-registry.yml
+++ b/.github/workflows/validate-registry.yml
@@ -54,14 +54,30 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
 
+      - name: Collect changed files
+        id: changes
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          {
+            echo "files<<CHANGED_FILES_EOF"
+            git diff --name-only "$BASE_SHA" HEAD
+            echo "CHANGED_FILES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Read build targets
         id: targets
+        env:
+          CHANGED_FILES: ${{ steps.changes.outputs.files }}
         run: echo "matrix=$(node scripts/list-build-targets.mjs)" >> "$GITHUB_OUTPUT"
 
   build-firmware:

--- a/scripts/list-build-targets.mjs
+++ b/scripts/list-build-targets.mjs
@@ -8,6 +8,29 @@ const ROOT_DIR = process.env.REGISTRY_ROOT
   : resolve(import.meta.dirname, '..');
 const INTEGRATIONS_DIR = join(ROOT_DIR, 'firmwares');
 
+// Paths that affect every firmware build rather than a single project.
+// 影响所有固件构建的路径，而不是只影响某一个项目。
+const SHARED_BUILD_PATHS = [
+  'scripts/',
+  'package.json',
+  'package-lock.json',
+  '.github/workflows/validate-registry.yml',
+];
+
+const changedFiles = (process.env.CHANGED_FILES || '')
+  .split('\n')
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+const buildsEverything = changedFiles.length === 0
+  || changedFiles.some((file) => SHARED_BUILD_PATHS.some((prefix) => file.startsWith(prefix)));
+
+// Reports whether the change set reaches the given firmware directory.
+// 判断本次改动是否涉及指定固件的目录。
+function isTouched(id) {
+  return buildsEverything || changedFiles.some((file) => file.startsWith(`firmwares/${id}/`));
+}
+
 function slugifyVersion(value) {
   const slug = String(value)
     .trim()
@@ -32,6 +55,7 @@ const targets = readdirSync(INTEGRATIONS_DIR, { withFileTypes: true })
       integration.build?.system !== 'esp-idf'
       || integration.catalogSection === 'draft'
       || version?.sourceBuild !== true
+      || !isTouched(integration.id)
     ) return null;
     return {
       id: integration.id,

--- a/scripts/list-build-targets.test.mjs
+++ b/scripts/list-build-targets.test.mjs
@@ -23,6 +23,36 @@ function writeIntegration(root, integration) {
   );
 }
 
+function writeSourceIntegration(root, id, name) {
+  writeIntegration(root, {
+    id,
+    name,
+    catalogSection: 'community',
+    build: {
+      system: 'esp-idf',
+      version: 'v5.3.2',
+      target: 'esp32s3',
+      projectPath: 'source',
+    },
+    flash: {
+      versions: [{ version: '1.0.0', sourceBuild: true }],
+    },
+  });
+}
+
+function runList(root, changedFiles) {
+  const result = spawnSync(process.execPath, [LIST_SCRIPT], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      REGISTRY_ROOT: root,
+      ...(changedFiles === undefined ? {} : { CHANGED_FILES: changedFiles }),
+    },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout).include.map((target) => target.id);
+}
+
 test('lists only publishable source-built integrations', () => {
   const root = mkdtempSync(join(tmpdir(), 'sticky-target-list-test-'));
   try {
@@ -82,6 +112,26 @@ test('lists only publishable source-built integrations', () => {
         versionSlug: '2.0.0-rc1',
       }],
     });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('narrows the target list to the firmwares a change touches', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sticky-target-list-test-'));
+  try {
+    writeSourceIntegration(root, 'alpha', 'Alpha');
+    writeSourceIntegration(root, 'beta', 'Beta');
+
+    assert.deepEqual(runList(root, undefined), ['alpha', 'beta']);
+    assert.deepEqual(runList(root, ''), ['alpha', 'beta']);
+    assert.deepEqual(
+      runList(root, 'printables/sticky-case/printable.json\nprintables/sticky-case/README.md'),
+      [],
+    );
+    assert.deepEqual(runList(root, 'firmwares/beta/source/main/main.c'), ['beta']);
+    assert.deepEqual(runList(root, 'scripts/package-esp-idf.mjs'), ['alpha', 'beta']);
+    assert.deepEqual(runList(root, '.github/workflows/validate-registry.yml'), ['alpha', 'beta']);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Pull requests that only add a 3D printable no longer trigger an ESP-IDF firmware build.

`list-build-targets.mjs` now reads an optional `CHANGED_FILES` list and keeps a firmware in the matrix when the change set reaches its directory. Changes under `scripts/`, `package.json`, `package-lock.json` or the workflow file still build every firmware, and pushes to `main` keep building everything because the variable is only set for pull requests.

The workflow collects the file list with `git diff` against the pull request base.

Verified with `npm test` (55 passing, including a new case covering the printables-only, single-firmware, and shared-script paths).