### PR TITLE
feat: build firmware with PlatformIO and Arduino in CI

### DIFF
--- a/.github/workflows/validate-registry.yml
+++ b/.github/workflows/validate-registry.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "firmwares/**"
       - "printables/**"
+      - "examples/**"
       - "schemas/**"
       - "scripts/**"
       - "package.json"
@@ -15,6 +16,7 @@ on:
     paths:
       - "firmwares/**"
       - "printables/**"
+      - "examples/**"
       - "schemas/**"
       - "scripts/**"
       - "package.json"
@@ -50,6 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.targets.outputs.matrix }}
+      channels: ${{ steps.channels.outputs.run }}
 
     steps:
       - name: Check out repository
@@ -80,6 +83,18 @@ jobs:
           CHANGED_FILES: ${{ steps.changes.outputs.files }}
         run: echo "matrix=$(node scripts/list-build-targets.mjs)" >> "$GITHUB_OUTPUT"
 
+      - name: Decide whether to smoke test the build channels
+        id: channels
+        env:
+          CHANGED_FILES: ${{ steps.changes.outputs.files }}
+        run: |
+          PIPELINE_PATHS='^(scripts/|examples/|package(-lock)?\.json|\.github/workflows/validate-registry\.yml)'
+          if [ -z "$CHANGED_FILES" ] || echo "$CHANGED_FILES" | grep -qE "$PIPELINE_PATHS"; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-firmware:
     name: Build ${{ matrix.id }}
     needs:
@@ -102,6 +117,7 @@ jobs:
           node-version: "20"
 
       - name: Build ESP-IDF project
+        if: ${{ matrix.system == 'esp-idf' }}
         uses: espressif/esp-idf-ci-action@v1
         with:
           esp_idf_version: ${{ matrix.idfVersion }}
@@ -109,11 +125,37 @@ jobs:
           path: ${{ matrix.path }}
           command: idf.py -D PROJECT_VER=${{ matrix.version }} build
 
+      - name: Set up Python
+        if: ${{ matrix.system == 'platformio' }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Build PlatformIO project
+        if: ${{ matrix.system == 'platformio' }}
+        env:
+          PLATFORMIO_EXTRA_SCRIPTS: post:${{ github.workspace }}/scripts/pio-dump-flash-args.py
+        run: |
+          pip install --upgrade platformio
+          pio run -d "${{ matrix.path }}" -e "${{ matrix.environment }}"
+
+      - name: Set up Arduino CLI
+        if: ${{ matrix.system == 'arduino' }}
+        uses: arduino/setup-arduino-cli@v2
+
+      - name: Build Arduino sketch
+        if: ${{ matrix.system == 'arduino' }}
+        run: |
+          arduino-cli compile \
+            --profile "${{ matrix.profile }}" \
+            --build-path "${{ matrix.path }}/build" \
+            "${{ matrix.path }}"
+
       - name: Package firmware
         env:
           FIRMWARE_OUTPUT_DIR: firmware-output/${{ matrix.id }}/${{ matrix.versionSlug }}
           REGISTRY_COMMIT: ${{ github.sha }}
-        run: npm run package:esp-idf -- "${{ matrix.id }}" "${{ matrix.version }}"
+        run: npm run "package:${{ matrix.system }}" -- "${{ matrix.id }}" "${{ matrix.version }}"
 
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v4
@@ -122,6 +164,55 @@ jobs:
           path: firmware-output/${{ matrix.id }}/${{ matrix.versionSlug }}
           if-no-files-found: error
           retention-days: 7
+
+  verify-build-channels:
+    name: Smoke test the ${{ matrix.system }} channel
+    needs:
+      - validate
+      - discover-firmware
+    if: ${{ needs.discover-firmware.outputs.channels == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        system:
+          - platformio
+          - arduino
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Set up Python
+        if: ${{ matrix.system == 'platformio' }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install PlatformIO
+        if: ${{ matrix.system == 'platformio' }}
+        run: pip install --upgrade platformio
+
+      - name: Set up Arduino CLI
+        if: ${{ matrix.system == 'arduino' }}
+        uses: arduino/setup-arduino-cli@v2
+
+      - name: Cache toolchain downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio
+            ~/.arduino15
+          key: build-channel-${{ matrix.system }}-${{ hashFiles('examples/platformio-starter/platformio.ini', 'examples/arduino-starter/sketch.yaml') }}
+
+      - name: Build and package the starter project
+        run: node scripts/verify-build-channel.mjs "${{ matrix.system }}"
 
   publish-firmware:
     name: Publish ${{ matrix.id }} ${{ matrix.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,14 +6,20 @@ npm-debug.log*
 !.env.example
 
 # Contributor source build output
-integrations/*/source/build/
-integrations/*/source/.cache/
-integrations/*/source/.vscode/
-integrations/*/source/.idea/
-integrations/*/source/managed_components/
-integrations/*/source/sdkconfig
-integrations/*/source/sdkconfig.old
-integrations/*/source/compile_commands.json
-integrations/*/source/*.elf
-integrations/*/source/*.map
+firmwares/*/*/build/
+firmwares/*/*/.pio/
+firmwares/*/*/.cache/
+firmwares/*/*/.vscode/
+firmwares/*/*/.idea/
+firmwares/*/*/managed_components/
+firmwares/*/*/sdkconfig
+firmwares/*/*/sdkconfig.old
+firmwares/*/*/compile_commands.json
+firmwares/*/*/*.elf
+firmwares/*/*/*.map
+
+# Starter project build output
+examples/*/build/
+examples/*/.pio/
+
 firmware-output/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,10 @@ file, template, and detailed guide.
 | Firmware that users flash from the Sticky website | `firmwares/<firmware-id>/` | `firmware.json` | `firmwares/_template/` | [Contributing firmware](docs/contributing-firmware.md) |
 | A 3D printable case, stand, mount, or accessory | `printables/<design-id>/` | `printable.json` | `printables/_template/` | [Contributing a 3D printable design](docs/contributing-printables.md) |
 
-- A **firmware** contribution ships either buildable ESP-IDF source that GitHub
-  Actions compiles, or a verified `.bin` package with a manifest. It needs a
-  physical-device test before review. Expect to spend an hour or two on the
-  first submission.
+- A **firmware** contribution ships either buildable ESP-IDF, PlatformIO, or
+  Arduino source that GitHub Actions compiles, or a verified `.bin` package with
+  a manifest. It needs a physical-device test before review. Expect to spend an
+  hour or two on the first submission.
 - A **printable** contribution is a card: one JSON file, one photo, one short
   README. The model files stay on your Printables / MakerWorld / Thingiverse /
   GrabCAD / GitHub page. Expect 15–30 minutes.
@@ -60,7 +60,7 @@ follow the detailed guide for your content type.
 | Git on your computer | Recommended | Optional | Printables can be submitted entirely in the GitHub web interface (see [Method B](#method-b-github-web-interface-no-git)) |
 | Node.js 20 or newer | Recommended | Optional | Runs the same checks locally that GitHub Actions runs on your PR |
 | A reTerminal Sticky | Yes | Yes | Firmware must be flashed and tested on a real device; printables need a photo of the print on a real device |
-| ESP-IDF | Optional | No | Only if you want to build firmware locally before submitting |
+| ESP-IDF, PlatformIO, or Arduino CLI | Optional | No | Only if you want to build firmware locally before submitting |
 
 ## 3. Repository layout
 
@@ -73,7 +73,7 @@ firmwares/                     one directory per firmware
     assets/
       preview.jpg              real Sticky screenshot or photo
       logo.svg                 optional identity image
-    source/                    source contributions: the ESP-IDF project
+    source/                    source contributions: the buildable project
     firmware/<version>/        firmware-only contributions: manifest.json + *.bin
 
 printables/                    one directory per printable design
@@ -93,6 +93,8 @@ scripts/
   create-flash-manifest.mjs    writes a firmware manifest; run with npm run create:manifest
   list-build-targets.mjs       finds source-built firmware for GitHub Actions
   package-esp-idf.mjs          turns an ESP-IDF build into manifest.json + .bin
+  package-platformio.mjs       same, for a PlatformIO build
+  package-arduino.mjs          same, for an Arduino build
 
 docs/
   contributing-firmware.md     detailed firmware guide (+ .zh-CN.md)
@@ -339,9 +341,9 @@ The metadata files only accept the fields listed in their guide. Remove the
 extra key, or check for a typo in a valid key.
 
 **How do I test firmware on my device before submitting?**
-Build locally with ESP-IDF and flash with `idf.py flash`, or use the PR
-artifact that GitHub Actions produces after you open the PR. The firmware guide
-describes both.
+Build locally with your project's toolchain and flash it from there, or use the
+PR artifact that GitHub Actions produces after you open the PR. The firmware
+guide describes both.
 
 **Who do I ask if something is unclear?**
 Open an issue in this repository, or ask in the pull request itself.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -30,9 +30,9 @@
 | 用户可以在 Sticky 网站直接烧录的固件 | `firmwares/<firmware-id>/` | `firmware.json` | `firmwares/_template/` | [贡献固件](docs/contributing-firmware.zh-CN.md) |
 | 3D 打印的外壳、支架、安装件或配件 | `printables/<design-id>/` | `printable.json` | `printables/_template/` | [贡献 3D 打印设计](docs/contributing-printables.zh-CN.md) |
 
-- **固件**贡献需要提交可编译的 ESP-IDF 源码（由 GitHub Actions 编译），或者一个
-  带 manifest 的、经过验证的 `.bin` 固件包，并在真机上测试后才能审核。第一次提交
-  预计一到两小时。
+- **固件**贡献需要提交可编译的 ESP-IDF、PlatformIO 或 Arduino 源码（由 GitHub
+  Actions 编译），或者一个带 manifest 的、经过验证的 `.bin` 固件包，并在真机上
+  测试后才能审核。第一次提交预计一到两小时。
 - **打印件**贡献只是一张卡片：一个 JSON 文件、一张照片、一份简短 README。模型文件
   留在你自己的 Printables / MakerWorld / Thingiverse / GrabCAD / GitHub 页面。
   预计 15–30 分钟。
@@ -56,7 +56,7 @@
 | 电脑上安装 Git | 推荐 | 可选 | 打印件可以完全在 GitHub 网页里完成，见[方式 B](#方式-bgithub-网页操作不需要-git) |
 | Node.js 20 或更高 | 推荐 | 可选 | 用来在本地跑和 GitHub Actions 相同的检查 |
 | 一台 reTerminal Sticky | 需要 | 需要 | 固件必须在真机上烧录测试；打印件需要一张装在真机上的照片 |
-| ESP-IDF | 可选 | 不需要 | 只有想在提交前本地编译固件时才需要 |
+| ESP-IDF、PlatformIO 或 Arduino CLI | 可选 | 不需要 | 只有想在提交前本地编译固件时才需要 |
 
 ## 3. 仓库结构
 
@@ -69,7 +69,7 @@ firmwares/                     每个固件一个目录
     assets/
       preview.jpg              真实的 Sticky 截图或照片
       logo.svg                 可选的标识图
-    source/                    源码模式：ESP-IDF 工程
+    source/                    源码模式：可编译的工程
     firmware/<version>/        仅固件包模式：manifest.json + *.bin
 
 printables/                    每个打印设计一个目录
@@ -89,6 +89,8 @@ scripts/
   create-flash-manifest.mjs    生成固件 manifest；通过 npm run create:manifest 运行
   list-build-targets.mjs       为 GitHub Actions 找出需要编译的源码固件
   package-esp-idf.mjs          把 ESP-IDF 编译结果整理成 manifest.json + .bin
+  package-platformio.mjs       同上，用于 PlatformIO 编译结果
+  package-arduino.mjs          同上，用于 Arduino 编译结果
 
 docs/
   contributing-firmware.md     固件详细指南（另有 .zh-CN.md）
@@ -305,7 +307,7 @@ Registry validation failed with 2 error(s):
 元数据文件只接受各自指南里列出的字段。删掉多出来的键，或检查合法键名是否拼错。
 
 **提交前怎么在自己的设备上测试固件？**
-用 ESP-IDF 本地编译并 `idf.py flash`，或者提交 PR 后使用 GitHub Actions 生成的 PR
+用项目自己的工具链在本地编译并烧录，或者提交 PR 后使用 GitHub Actions 生成的 PR
 产物。固件指南对两种方式都有说明。
 
 **有不清楚的地方问谁？**

--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ scripts/
   validate-registry.mjs
   list-build-targets.mjs
   package-esp-idf.mjs
+  package-platformio.mjs
+  package-arduino.mjs
   verify-esp-idf-build.mjs
+  verify-build-channel.mjs
+examples/
+  platformio-starter/
+  arduino-starter/
 docs/
   contributing-firmware.md / .zh-CN.md
   contributing-printables.md / .zh-CN.md
@@ -88,7 +94,7 @@ npm run create:manifest -- <firmware-id> <version>   # firmware-only packages
 `npm run validate` checks every directory under `firmwares/` and `printables/`.
 `npm run create:manifest` writes `firmware/<version>/manifest.json` from the
 `.bin` files in that directory, filling in every size and SHA-256.
-For source-built firmware, declare the project's ESP-IDF version in
-`firmware.json` and set the newest version to `sourceBuild: true`; GitHub
-Actions builds the project, packages ESP-IDF's flash map, and publishes the
-firmware Release after merge.
+For source-built firmware, declare the project's build system in `firmware.json`
+and set the newest version to `sourceBuild: true`; GitHub Actions builds the
+project with ESP-IDF, PlatformIO, or Arduino, packages the toolchain's flash map,
+and publishes the firmware Release after merge.

--- a/docs/contributing-firmware.md
+++ b/docs/contributing-firmware.md
@@ -24,7 +24,7 @@ Shared review and release steps live in [CONTRIBUTING.md](../CONTRIBUTING.md).
 - [Contribution paths](#contribution-paths): [source](#source-contribution) or [firmware-only](#firmware-only-package) (with the [manifest.json reference](#manifestjson-for-a-firmware-only-package))
 - [Official Sticky firmware updates](#official-sticky-firmware-updates)
 - [Source contribution requirements](#source-contribution-requirements)
-- [Optional local ESP-IDF build](#optional-local-esp-idf-build)
+- [Optional local build](#optional-local-build)
 - [Local validation](#local-validation) and [common validation errors](#common-validation-errors)
 - [Submitting the pull request](#submitting-the-pull-request)
 - [Physical device test](#physical-device-test)
@@ -242,7 +242,7 @@ Community firmware categories:
 | `origin.url` | string | No | HTTPS URL | Link for `origin.name` |
 | `source.url` | string | Yes | HTTPS URL | Upstream source repository, for both contribution paths |
 | `source.license` | string | Required for firmware-only | 1–80 chars | SPDX-style license id such as `MIT`, `GPL-3.0`, `Apache-2.0` |
-| `source.path` | string | Required for source contributions | relative path inside the directory, normally `source` | Directory containing the ESP-IDF project |
+| `source.path` | string | Required for source contributions | relative path inside the directory, normally `source` | Directory containing the project; Arduino uses the sketch name |
 | `support.url` | string | Yes | HTTPS URL | Where users report problems, normally the issue tracker |
 | `documentationUrl` | string | No | HTTPS URL | User documentation, normally the upstream README |
 
@@ -260,10 +260,15 @@ Community firmware categories:
 
 | Field | Type | Required | Limits | What to write |
 |---|---|---|---|---|
-| `build.system` | string | Yes | must be `esp-idf` | `esp-idf` |
-| `build.version` | string | Yes | up to 64 chars, `^[A-Za-z0-9][A-Za-z0-9._-]*$` | ESP-IDF version the project builds with: `v5.4`, `v5.3.2`, `latest` |
-| `build.target` | string | Yes | up to 40 chars | `esp32s3` (reTerminal Sticky uses an ESP32-S3) |
+| `build.system` | string | Yes | `esp-idf`, `platformio`, or `arduino` | The build system the project already uses |
+| `build.version` | string | ESP-IDF only | up to 64 chars, `^[A-Za-z0-9][A-Za-z0-9._-]*$` | ESP-IDF version the project builds with: `v5.4`, `v5.3.2`, `latest` |
+| `build.target` | string | ESP-IDF only | up to 40 chars | `esp32s3` (reTerminal Sticky uses an ESP32-S3) |
+| `build.environment` | string | PlatformIO only | up to 64 chars, `^[A-Za-z0-9][A-Za-z0-9._-]*$` | `platformio.ini` environment name, without the `env:` prefix |
+| `build.profile` | string | Arduino only | up to 64 chars, `^[A-Za-z0-9][A-Za-z0-9._-]*$` | `sketch.yaml` profile name |
 | `build.projectPath` | string | Yes | relative path | Same value as `source.path` |
+
+Each build system accepts only its own fields. Write `version` and `target` for
+ESP-IDF, `environment` for PlatformIO, and `profile` for Arduino.
 
 Omit the whole `build` object for firmware-only packages.
 
@@ -434,8 +439,11 @@ applicable license.
 Use placeholders or runtime setup for user-specific Wi-Fi credentials, API
 keys, tokens, and passwords.
 
-The first automated build path supports ESP-IDF projects. A typical source tree
-contains:
+CI builds ESP-IDF, PlatformIO, and Arduino projects. Pick the one your project
+already uses and declare it in `build.system`. Starting points for PlatformIO and
+Arduino live in [examples/](../examples/README.md).
+
+### ESP-IDF
 
 ```text
 source/
@@ -448,26 +456,108 @@ source/
   LICENSE
 ```
 
-Projects that need another build system should open an issue first so the
-maintainers can add a reproducible CI build adapter before the firmware PR.
+```json
+"build": {
+  "system": "esp-idf",
+  "version": "v5.4",
+  "target": "esp32s3",
+  "projectPath": "source"
+}
+```
 
-The `build.version` field selects the ESP-IDF version used by GitHub Actions.
-Declare the version already used by the project, for example `v5.0.5`, `v5.3.2`,
-or `latest`.
+`build.version` selects the ESP-IDF Docker image tag, for example `v5.0.5`,
+`v5.3.2`, or `latest`.
 
-## Optional local ESP-IDF build
+### PlatformIO
 
-Authors may build locally before opening the PR. Install the ESP-IDF version
-declared in `firmware.json`, then run from the integration source directory:
+```text
+source/
+  platformio.ini
+  src/
+    main.cpp
+  LICENSE
+```
+
+```json
+"build": {
+  "system": "platformio",
+  "environment": "sticky",
+  "projectPath": "source"
+}
+```
+
+`build.environment` names the `[env:...]` section CI builds, without the `env:`
+prefix. Pin the platform version in `platformio.ini` so a rebuild produces the
+same binary:
+
+```ini
+[env:sticky]
+platform = espressif32@6.13.0
+board = esp32-s3-devkitc-1
+framework = arduino
+```
+
+### Arduino
+
+Arduino CLI requires the sketch directory and the `.ino` file to share a name, so
+name the project directory after the sketch instead of using `source`:
+
+```text
+my-sketch/
+  my-sketch.ino
+  sketch.yaml
+  LICENSE
+```
+
+```json
+"build": {
+  "system": "arduino",
+  "profile": "sticky",
+  "projectPath": "my-sketch"
+}
+```
+
+`build.profile` names a profile in `sketch.yaml`. A profile pins the board core
+and every library, which is what makes the build reproducible:
+
+```yaml
+profiles:
+  sticky:
+    fqbn: esp32:esp32:esp32s3
+    platforms:
+      - platform: esp32:esp32 (3.3.11)
+        platform_index_url: https://espressif.github.io/arduino-esp32/package_esp32_index.json
+default_profile: sticky
+```
+
+Add the board options your firmware needs to the `fqbn`, for example
+`esp32:esp32:esp32s3:PSRAM=opi,FlashSize=32M` for the 32 MB flash and octal PSRAM
+that reTerminal Sticky ships.
+
+Projects on another build system should open an issue first so the maintainers can
+add a reproducible CI build adapter before the firmware PR.
+
+## Optional local build
+
+Authors may build locally before opening the PR. Run the command for the declared
+build system from the project directory:
 
 ```bash
+# ESP-IDF
 idf.py set-target esp32s3
 idf.py -D PROJECT_VER=1.0.0 build
+
+# PlatformIO
+pio run -e sticky
+
+# Arduino
+arduino-cli compile --profile sticky
 ```
 
 This local build verifies the project before submission. The Registry ignores
-the local `build/`, generated `sdkconfig`, dependency cache, and editor settings.
-GitHub Actions performs the official build and packaging after the PR is opened.
+local build output, generated configuration, dependency caches, and editor
+settings. GitHub Actions performs the official build and packaging after the PR
+is opened.
 
 ## Local validation
 
@@ -483,7 +573,7 @@ The validator checks:
 - directory and ID consistency;
 - required metadata and HTTPS links;
 - the integration README and declared source license;
-- local source and ESP-IDF project files when `source.path` is present;
+- local source and the build system's project files when `source.path` is present;
 - image file signatures and static SVG safety;
 - local manifest structure;
 - firmware file existence, byte size, and SHA-256;
@@ -506,7 +596,8 @@ against the files committed in the PR.
 | `...firmware.json.author: is required for community firmware` | Missing `author` | Add `author.name` |
 | `...firmware.json.source.license: is required for firmware-only packages` | Firmware-only without a license id | Add `source.license` |
 | `...firmware.json.build: is required when source.path is provided` | Source contribution without `build` | Add the `build` object |
-| `...firmware.json.build.projectPath: must contain CMakeLists.txt for an ESP-IDF project` | `source/` is empty or points at the wrong directory | Commit the ESP-IDF project root under `source/` |
+| `...firmware.json.build.projectPath: must contain CMakeLists.txt for the esp-idf build system` | `projectPath` is empty or points at the wrong directory | Commit the project root there. PlatformIO needs `platformio.ini`, Arduino needs `sketch.yaml` |
+| `...firmware.json.build: contains unsupported field "target"` | Fields from another build system | Keep only the fields your `build.system` accepts |
 | `...flash.versions[0].sourceBuild: must be true for a source contribution` | Newest version lacks `sourceBuild` | Set `"sourceBuild": true` on the first entry |
 | `...flash.versions[0]: must use exactly one firmware delivery method` | `sourceBuild` and `manifestPath` both set, or neither | Keep one |
 | `...manifestPath: must be inside the firmware/ directory` | Manifest stored elsewhere | Move to `firmware/<version>/manifest.json` |
@@ -573,8 +664,8 @@ The pull request contains the selected contribution path, metadata, assets, and
 hardware test result. GitHub Actions performs these checks:
 
 1. Validate the Registry structure and every firmware-only package.
-2. Build source-contribution ESP-IDF projects with each project-declared IDF version.
-3. Generate the flash manifest and firmware package from ESP-IDF's flash map.
+2. Build source contributions with the toolchain version the project declares.
+3. Generate the flash manifest and firmware package from the toolchain's flash map.
 4. Upload the generated package as a temporary PR artifact for maintainer review.
 
 The pull request remains under review until these checks pass and the maintainer

--- a/docs/contributing-firmware.zh-CN.md
+++ b/docs/contributing-firmware.zh-CN.md
@@ -21,7 +21,7 @@
 - [两种贡献方式](#两种贡献方式)：[源码模式](#源码模式) 或 [仅固件包](#仅固件包)（含 [manifest.json 说明](#仅固件包的-manifestjson)）
 - [Sticky 官方固件更新](#sticky-官方固件更新)
 - [源码模式要求](#源码模式要求)
-- [可选的本地 ESP-IDF 编译](#可选的本地-esp-idf-编译)
+- [可选的本地编译](#可选的本地编译)
 - [本地自动检查](#本地自动检查) 及[常见校验报错](#常见校验报错)
 - [提交 pull request](#提交-pull-request)
 - [真实设备测试](#真实设备测试)
@@ -242,7 +242,7 @@ cp -R firmwares/_template firmwares/my-firmware
 | `origin.url` | 字符串 | 否 | HTTPS 网址 | `origin.name` 的链接 |
 | `source.url` | 字符串 | 是 | HTTPS 网址 | 上游源码仓库，两种贡献方式都要填 |
 | `source.license` | 字符串 | 仅固件包必填 | 1–80 字符 | SPDX 风格的许可证标识，如 `MIT`、`GPL-3.0`、`Apache-2.0` |
-| `source.path` | 字符串 | 源码模式必填 | 目录内的相对路径，通常是 `source` | 存放 ESP-IDF 工程的目录 |
+| `source.path` | 字符串 | 源码模式必填 | 目录内的相对路径，通常是 `source` | 存放工程的目录；Arduino 用 sketch 的名字 |
 | `support.url` | 字符串 | 是 | HTTPS 网址 | 用户反馈问题的地方，通常是 issue 页面 |
 | `documentationUrl` | 字符串 | 否 | HTTPS 网址 | 用户文档，通常是上游 README |
 
@@ -260,10 +260,15 @@ cp -R firmwares/_template firmwares/my-firmware
 
 | 字段 | 类型 | 必填 | 限制 | 填什么 |
 |---|---|---|---|---|
-| `build.system` | 字符串 | 是 | 必须是 `esp-idf` | `esp-idf` |
-| `build.version` | 字符串 | 是 | 最长 64 字符，`^[A-Za-z0-9][A-Za-z0-9._-]*$` | 项目使用的 ESP-IDF 版本：`v5.4`、`v5.3.2`、`latest` |
-| `build.target` | 字符串 | 是 | 最长 40 字符 | `esp32s3`（reTerminal Sticky 使用 ESP32-S3） |
+| `build.system` | 字符串 | 是 | `esp-idf`、`platformio` 或 `arduino` | 项目本来在用的编译系统 |
+| `build.version` | 字符串 | 仅 ESP-IDF | 最长 64 字符，`^[A-Za-z0-9][A-Za-z0-9._-]*$` | 项目使用的 ESP-IDF 版本：`v5.4`、`v5.3.2`、`latest` |
+| `build.target` | 字符串 | 仅 ESP-IDF | 最长 40 字符 | `esp32s3`（reTerminal Sticky 使用 ESP32-S3） |
+| `build.environment` | 字符串 | 仅 PlatformIO | 最长 64 字符，`^[A-Za-z0-9][A-Za-z0-9._-]*$` | `platformio.ini` 里的环境名，不带 `env:` 前缀 |
+| `build.profile` | 字符串 | 仅 Arduino | 最长 64 字符，`^[A-Za-z0-9][A-Za-z0-9._-]*$` | `sketch.yaml` 里的配置档名称 |
 | `build.projectPath` | 字符串 | 是 | 相对路径 | 与 `source.path` 相同 |
+
+每种编译系统只接受属于自己的字段：ESP-IDF 写 `version` 和 `target`，PlatformIO 写
+`environment`，Arduino 写 `profile`。
 
 仅固件包模式请整个省略 `build` 对象。
 
@@ -419,7 +424,11 @@ shasum -a 256 *.bin         # sha256（macOS/Linux）；Windows 用 certutil -ha
 
 Wi-Fi 密码、API Key、Token 和密码等用户私密信息使用占位符或首次运行配置方式。
 
-第一阶段的自动编译流程支持 ESP-IDF，常见目录如下：
+自动编译流程支持 ESP-IDF、PlatformIO 和 Arduino 三种编译系统。选择项目本来就在用
+的那一种，写进 `build.system`。PlatformIO 和 Arduino 的起步工程放在
+[examples/](../examples/README.md)。
+
+### ESP-IDF
 
 ```text
 source/
@@ -432,26 +441,105 @@ source/
   LICENSE
 ```
 
-需要其他编译系统的项目，先提交 Issue，让维护者先为该编译系统加入可重复执行的 CI
-构建适配，再提交正式固件 PR。
+```json
+"build": {
+  "system": "esp-idf",
+  "version": "v5.4",
+  "target": "esp32s3",
+  "projectPath": "source"
+}
+```
 
-`build.version` 决定 GitHub Actions 使用哪个 ESP-IDF 版本。贡献者填写项目实际使用
-的版本，例如 `v5.0.5`、`v5.3.2` 或 `latest`，流程不会统一锁定到某个固定版本。
+`build.version` 决定 GitHub Actions 使用哪个 ESP-IDF 镜像版本，例如 `v5.0.5`、
+`v5.3.2` 或 `latest`，流程不会统一锁定到某个固定版本。
+
+### PlatformIO
+
+```text
+source/
+  platformio.ini
+  src/
+    main.cpp
+  LICENSE
+```
+
+```json
+"build": {
+  "system": "platformio",
+  "environment": "sticky",
+  "projectPath": "source"
+}
+```
+
+`build.environment` 指定要编译哪个 `[env:...]` 段落，不带 `env:` 前缀。在
+`platformio.ini` 里锁定平台版本，重新编译才能得到相同的二进制：
+
+```ini
+[env:sticky]
+platform = espressif32@6.13.0
+board = esp32-s3-devkitc-1
+framework = arduino
+```
+
+### Arduino
+
+Arduino CLI 要求 sketch 目录名与 `.ino` 文件名相同，因此工程目录用 sketch 的名字，
+不要叫 `source`：
+
+```text
+my-sketch/
+  my-sketch.ino
+  sketch.yaml
+  LICENSE
+```
+
+```json
+"build": {
+  "system": "arduino",
+  "profile": "sticky",
+  "projectPath": "my-sketch"
+}
+```
+
+`build.profile` 指定 `sketch.yaml` 里的一个配置档。配置档会锁定开发板内核和每一个
+库的版本，这是编译结果可复现的关键：
+
+```yaml
+profiles:
+  sticky:
+    fqbn: esp32:esp32:esp32s3
+    platforms:
+      - platform: esp32:esp32 (3.3.11)
+        platform_index_url: https://espressif.github.io/arduino-esp32/package_esp32_index.json
+default_profile: sticky
+```
+
+固件需要的开发板选项写进 `fqbn`，例如 reTerminal Sticky 的 32 MB Flash 与八线
+PSRAM 对应 `esp32:esp32:esp32s3:PSRAM=opi,FlashSize=32M`。
+
+使用其他编译系统的项目，先提交 Issue，让维护者先为该编译系统加入可重复执行的 CI
+构建适配，再提交正式固件 PR。
 
 一句话总结：源码必须让审核机器能够从零重新编译，而不是只留一个外部链接。
 
-## 可选的本地 ESP-IDF 编译
+## 可选的本地编译
 
-作者可以在提交 PR 前先做一次本地编译。安装 `firmware.json` 中声明的 ESP-IDF
-版本，然后进入项目的 `source/` 目录执行：
+作者可以在提交 PR 前先做一次本地编译。按声明的编译系统，在工程目录里执行对应命令：
 
 ```bash
+# ESP-IDF
 idf.py set-target esp32s3
 idf.py -D PROJECT_VER=1.0.0 build
+
+# PlatformIO
+pio run -e sticky
+
+# Arduino
+arduino-cli compile --profile sticky
 ```
 
-这一步用于作者在提交前确认工程能正常编译。Registry 会忽略本地生成的 `build/`、
-`sdkconfig`、依赖缓存和编辑器配置。PR 提交后，正式固件由 GitHub Actions 重新编译
+这一步用于作者在提交前确认工程能正常编译。Registry 会忽略本地生成的编译产物、
+配置文件、依赖缓存和编辑器配置。PR 提交后，正式固件由 GitHub Actions 重新编译
 并整理，无需把本机生成的文件放进 PR。
 
 一句话总结：本地编译是可选自测，正式固件统一由 Action 生成。
@@ -470,7 +558,7 @@ npm run validate
 - 目录名与项目 ID 一致；
 - 必填资料和 HTTPS 链接完整；
 - 项目 README 和声明的源码许可证存在；
-- 设置 `source.path` 时，本地源码目录和 ESP-IDF 工程文件存在；
+- 设置 `source.path` 时，本地源码目录和该编译系统的工程文件存在；
 - 图片格式正确，SVG 只包含静态内容；
 - manifest 结构正确；
 - 每个已提交固件文件存在，大小和 SHA-256 一致；
@@ -494,7 +582,8 @@ PR 中提交的文件。
 | `...firmware.json.author: is required for community firmware` | 缺 `author` | 补上 `author.name` |
 | `...firmware.json.source.license: is required for firmware-only packages` | 仅固件包没写许可证 | 补上 `source.license` |
 | `...firmware.json.build: is required when source.path is provided` | 源码模式缺 `build` | 补上 `build` 对象 |
-| `...firmware.json.build.projectPath: must contain CMakeLists.txt for an ESP-IDF project` | `source/` 为空或指错目录 | 把 ESP-IDF 工程根目录提交到 `source/` |
+| `...firmware.json.build.projectPath: must contain CMakeLists.txt for the esp-idf build system` | `projectPath` 为空或指错目录 | 把工程根目录提交到该路径。PlatformIO 需要 `platformio.ini`，Arduino 需要 `sketch.yaml` |
+| `...firmware.json.build: contains unsupported field "target"` | 混用了其他编译系统的字段 | 只保留当前 `build.system` 接受的字段 |
 | `...flash.versions[0].sourceBuild: must be true for a source contribution` | 最新版本没有 `sourceBuild` | 第一项加上 `"sourceBuild": true` |
 | `...flash.versions[0]: must use exactly one firmware delivery method` | `sourceBuild` 和 `manifestPath` 同时出现，或都没有 | 只保留一种 |
 | `...manifestPath: must be inside the firmware/ directory` | manifest 放错位置 | 移到 `firmware/<version>/manifest.json` |
@@ -556,8 +645,8 @@ PR 需要包含所选贡献方式对应的内容、项目资料、图片和实�
 GitHub Actions 会依次执行：
 
 1. 检查 Registry 结构和仅固件包模式提交的文件。
-2. 按每个源码项目声明的 ESP-IDF 版本进行编译。
-3. 根据 ESP-IDF 烧录表自动生成 manifest 和完整固件包。
+2. 按每个源码项目声明的工具链版本进行编译。
+3. 根据工具链给出的烧录表自动生成 manifest 和完整固件包。
 4. 把生成的固件作为 PR 临时构建产物，供维护者下载审核。
 
 当这些检查通过，并且维护者确认项目用途、许可证、兼容性和实机结果后，PR 才进入合并。

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,33 @@
+# Firmware starter projects
+
+Minimal projects for the build systems the Registry compiles in CI. Copy one into
+your firmware entry as `source/`, then point `build` in `firmware.json` at it.
+
+| Directory | Build system | `firmware.json` build block |
+| --- | --- | --- |
+| `platformio-starter/` | PlatformIO | `{ "system": "platformio", "environment": "sticky", "projectPath": "source" }` |
+| `arduino-starter/` | Arduino CLI | `{ "system": "arduino", "profile": "sticky", "projectPath": "source" }` |
+
+For ESP-IDF projects, start from `firmwares/_template/source/`.
+
+CI compiles both starters on every change to the build pipeline, so they double as a
+health check for the PlatformIO and Arduino channels.
+
+## Pinning toolchain versions
+
+Both starters pin the toolchain version that builds them: `platform = espressif32@6.13.0`
+in `platformio.ini`, and `platform: esp32:esp32 (3.3.11)` in `sketch.yaml`. Keep a pin in
+your own project so a rebuild months from now produces the same binary. Choose whichever
+version your code needs.
+
+## Board settings
+
+The starters use stock ESP32-S3 board settings so they stay easy to compile. reTerminal
+Sticky ships 32 MB of flash and octal PSRAM, so a real firmware usually adds:
+
+- PlatformIO: `board_upload.flash_size` and `board_build.arduino.memory_type` in `platformio.ini`
+- Arduino: the matching `PSRAM` and `FlashSize` options in the `fqbn` string, for example
+  `esp32:esp32:esp32s3:PSRAM=opi,FlashSize=32M`
+
+See [docs/contributing-firmware.md](../docs/contributing-firmware.md) for the full
+contribution flow.

--- a/examples/arduino-starter/arduino-starter.ino
+++ b/examples/arduino-starter/arduino-starter.ino
@@ -1,0 +1,8 @@
+void setup() {
+  Serial.begin(115200);
+}
+
+void loop() {
+  Serial.println("Hello from reTerminal Sticky");
+  delay(1000);
+}

--- a/examples/arduino-starter/sketch.yaml
+++ b/examples/arduino-starter/sketch.yaml
@@ -1,0 +1,8 @@
+profiles:
+  sticky:
+    notes: Starting point for an Arduino firmware contribution.
+    fqbn: esp32:esp32:esp32s3
+    platforms:
+      - platform: esp32:esp32 (3.3.11)
+        platform_index_url: https://espressif.github.io/arduino-esp32/package_esp32_index.json
+default_profile: sticky

--- a/examples/platformio-starter/platformio.ini
+++ b/examples/platformio-starter/platformio.ini
@@ -1,0 +1,7 @@
+; Starting point for a PlatformIO firmware contribution.
+; Pin the platform version so every build produces the same binary.
+[env:sticky]
+platform = espressif32@6.13.0
+board = esp32-s3-devkitc-1
+framework = arduino
+monitor_speed = 115200

--- a/examples/platformio-starter/src/main.cpp
+++ b/examples/platformio-starter/src/main.cpp
@@ -1,0 +1,10 @@
+#include <Arduino.h>
+
+void setup() {
+  Serial.begin(115200);
+}
+
+void loop() {
+  Serial.println("Hello from reTerminal Sticky");
+  delay(1000);
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "test": "node --test scripts/*.test.mjs",
     "validate": "node scripts/validate-registry.mjs",
     "create:manifest": "node scripts/create-flash-manifest.mjs",
-    "package:esp-idf": "node scripts/package-esp-idf.mjs"
+    "package:esp-idf": "node scripts/package-esp-idf.mjs",
+    "package:platformio": "node scripts/package-platformio.mjs",
+    "package:arduino": "node scripts/package-arduino.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/schemas/firmware.schema.json
+++ b/schemas/firmware.schema.json
@@ -191,32 +191,90 @@
     },
     "build": {
       "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "system",
-        "version",
-        "target",
-        "projectPath"
-      ],
-      "properties": {
-        "system": {
-          "const": "esp-idf"
+      "description": "Toolchain settings the Registry uses to build this firmware in CI.",
+      "oneOf": [
+        {
+          "title": "ESP-IDF",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "system",
+            "version",
+            "target",
+            "projectPath"
+          ],
+          "properties": {
+            "system": {
+              "const": "esp-idf"
+            },
+            "version": {
+              "type": "string",
+              "description": "ESP-IDF Docker image tag used to build this firmware.",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+              "maxLength": 64
+            },
+            "target": {
+              "type": "string",
+              "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+              "maxLength": 40
+            },
+            "projectPath": {
+              "description": "Directory that contains CMakeLists.txt.",
+              "$ref": "#/$defs/localPath"
+            }
+          }
         },
-        "version": {
-          "type": "string",
-          "description": "ESP-IDF Docker image tag used to build this firmware.",
-          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
-          "maxLength": 64
+        {
+          "title": "PlatformIO",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "system",
+            "environment",
+            "projectPath"
+          ],
+          "properties": {
+            "system": {
+              "const": "platformio"
+            },
+            "environment": {
+              "type": "string",
+              "description": "platformio.ini environment name to build, without the \"env:\" prefix.",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+              "maxLength": 64
+            },
+            "projectPath": {
+              "description": "Directory that contains platformio.ini.",
+              "$ref": "#/$defs/localPath"
+            }
+          }
         },
-        "target": {
-          "type": "string",
-          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
-          "maxLength": 40
-        },
-        "projectPath": {
-          "$ref": "#/$defs/localPath"
+        {
+          "title": "Arduino",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "system",
+            "profile",
+            "projectPath"
+          ],
+          "properties": {
+            "system": {
+              "const": "arduino"
+            },
+            "profile": {
+              "type": "string",
+              "description": "sketch.yaml profile name that pins the board core and libraries.",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+              "maxLength": 64
+            },
+            "projectPath": {
+              "description": "Sketch directory that contains sketch.yaml.",
+              "$ref": "#/$defs/localPath"
+            }
+          }
         }
-      }
+      ]
     },
     "external": {
       "type": "object",

--- a/scripts/firmware-package.mjs
+++ b/scripts/firmware-package.mjs
@@ -1,0 +1,154 @@
+import { createHash } from 'node:crypto';
+import {
+  copyFileSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+
+const CHIP_FAMILY = 'ESP32-S3';
+
+const ROOT_DIR = process.env.REGISTRY_ROOT
+  ? resolve(process.env.REGISTRY_ROOT)
+  : resolve(import.meta.dirname, '..');
+
+function parseOffset(value) {
+  const text = String(value).trim();
+  const offset = /^0x/i.test(text) ? Number.parseInt(text, 16) : Number.parseInt(text, 10);
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new Error(`Invalid flash offset "${value}". Use a decimal number or a 0x-prefixed address`);
+  }
+  return offset;
+}
+
+// Loads a firmware entry built with the given system and resolves its project and output directories.
+// 读取由指定编译系统构建的固件条目,并解析出它的工程目录与产物目录。
+export function resolveTarget(system, integrationId, versionLabel) {
+  if (!integrationId || !versionLabel) {
+    throw new Error(`Usage: npm run package:${system} -- <firmware-id> <version>`);
+  }
+
+  const integrationDir = join(ROOT_DIR, 'firmwares', integrationId);
+  const integration = JSON.parse(readFileSync(join(integrationDir, 'firmware.json'), 'utf8'));
+  if (integration.id !== integrationId || integration.build?.system !== system) {
+    throw new Error(`${integrationId} is not configured as a ${system} firmware`);
+  }
+
+  const version = integration.flash?.versions?.find((entry) => entry.version === versionLabel);
+  if (!version) {
+    throw new Error(`${integrationId} does not define firmware version ${versionLabel}`);
+  }
+  if (!version.manifestPath && version.sourceBuild !== true) {
+    throw new Error(`${integrationId} ${versionLabel} does not define a package destination`);
+  }
+
+  const configuredOutputDir = process.env.FIRMWARE_OUTPUT_DIR;
+  if (version.sourceBuild === true && !configuredOutputDir) {
+    throw new Error('FIRMWARE_OUTPUT_DIR is required for a source-built firmware package');
+  }
+
+  return {
+    integration,
+    projectDir: join(integrationDir, integration.build.projectPath),
+    outputDir: configuredOutputDir
+      ? resolve(configuredOutputDir)
+      : join(integrationDir, dirname(version.manifestPath)),
+  };
+}
+
+// Reads an ESP-IDF style flasher_args.json into an offset and file list.
+// 读取 ESP-IDF 风格的 flasher_args.json,得到偏移地址与文件清单。
+export function readFlasherArgsJson(buildDir) {
+  const flashArgs = JSON.parse(readFileSync(join(buildDir, 'flasher_args.json'), 'utf8'));
+  return {
+    files: Object.entries(flashArgs.flash_files || {}).map(([offset, relativePath]) => ({
+      offset: parseOffset(offset),
+      sourcePath: join(buildDir, relativePath),
+    })),
+    flashSize: flashArgs.flash_settings?.flash_size,
+  };
+}
+
+// Reads the flash_args file that the arduino-esp32 core writes next to its build artifacts.
+// 读取 arduino-esp32 内核在编译产物旁生成的 flash_args 文件。
+export function readArduinoFlashArgs(buildDir) {
+  const lines = readFileSync(join(buildDir, 'flash_args'), 'utf8')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const settings = lines.shift() ?? '';
+
+  return {
+    files: lines.map((line) => {
+      const [offset, relativePath] = line.split(/\s+/);
+      if (!offset || !relativePath) {
+        throw new Error(`Cannot read a flash offset and file name from "${line}"`);
+      }
+      return { offset: parseOffset(offset), sourcePath: join(buildDir, relativePath) };
+    }),
+    flashSize: /--flash[-_]size\s+(\S+)/.exec(settings)?.[1],
+  };
+}
+
+// Copies every flash file into the output directory and writes the Registry manifest beside them.
+// 把每个烧录文件复制到产物目录,并在旁边生成 Registry 格式的 manifest。
+export function writeFirmwarePackage({
+  integration,
+  versionLabel,
+  outputDir,
+  files,
+  flashSize,
+}) {
+  if (files.length === 0) {
+    throw new Error(`No flash files were found for ${integration.id} ${versionLabel}`);
+  }
+
+  mkdirSync(outputDir, { recursive: true });
+  const packagedNames = new Set();
+  const parts = files
+    .map(({ offset, sourcePath }) => {
+      const fileName = basename(sourcePath);
+      if (packagedNames.has(fileName)) {
+        throw new Error(`The flash map contains duplicate filename ${fileName}`);
+      }
+      packagedNames.add(fileName);
+      const content = readFileSync(sourcePath);
+      copyFileSync(sourcePath, join(outputDir, fileName));
+      return {
+        path: fileName,
+        offset,
+        size: content.length,
+        sha256: createHash('sha256').update(content).digest('hex'),
+      };
+    })
+    .sort((left, right) => left.offset - right.offset);
+
+  const manifest = {
+    integrationId: integration.id,
+    name: integration.name,
+    version: versionLabel,
+    flashSize,
+    builds: [
+      {
+        chipFamily: CHIP_FAMILY,
+        parts,
+      },
+    ],
+  };
+
+  if (process.env.REGISTRY_COMMIT) {
+    if (!/^[a-f0-9]{40}$/.test(process.env.REGISTRY_COMMIT)) {
+      throw new Error('REGISTRY_COMMIT must be a full lowercase commit SHA');
+    }
+    manifest.registryCommit = process.env.REGISTRY_COMMIT;
+  }
+
+  writeFileSync(
+    join(outputDir, 'manifest.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    'utf8',
+  );
+
+  return parts;
+}

--- a/scripts/list-build-targets.mjs
+++ b/scripts/list-build-targets.mjs
@@ -31,6 +31,20 @@ function isTouched(id) {
   return buildsEverything || changedFiles.some((file) => file.startsWith(`firmwares/${id}/`));
 }
 
+const BUILD_SYSTEMS = new Set(['esp-idf', 'platformio', 'arduino']);
+
+// Maps a build block to the toolchain arguments its CI step needs.
+// 把 build 段落转换为对应编译步骤所需的工具链参数。
+function buildSettings(build) {
+  if (build.system === 'esp-idf') {
+    return { idfVersion: build.version, target: build.target };
+  }
+  if (build.system === 'platformio') {
+    return { environment: build.environment };
+  }
+  return { profile: build.profile };
+}
+
 function slugifyVersion(value) {
   const slug = String(value)
     .trim()
@@ -52,7 +66,7 @@ const targets = readdirSync(INTEGRATIONS_DIR, { withFileTypes: true })
     ));
     const version = integration.flash?.versions?.[0];
     if (
-      integration.build?.system !== 'esp-idf'
+      !BUILD_SYSTEMS.has(integration.build?.system)
       || integration.catalogSection === 'draft'
       || version?.sourceBuild !== true
       || !isTouched(integration.id)
@@ -60,9 +74,9 @@ const targets = readdirSync(INTEGRATIONS_DIR, { withFileTypes: true })
     return {
       id: integration.id,
       name: integration.name,
+      system: integration.build.system,
       path: `firmwares/${integration.id}/${integration.build.projectPath}`,
-      idfVersion: integration.build.version,
-      target: integration.build.target,
+      ...buildSettings(integration.build),
       version: version.version,
       versionSlug: slugifyVersion(version.version),
     };

--- a/scripts/list-build-targets.test.mjs
+++ b/scripts/list-build-targets.test.mjs
@@ -105,12 +105,75 @@ test('lists only publishable source-built integrations', () => {
       include: [{
         id: 'source-project',
         name: 'Source Project',
+        system: 'esp-idf',
         path: 'firmwares/source-project/source',
         idfVersion: 'v5.3.2',
         target: 'esp32s3',
         version: '2.0.0 RC1',
         versionSlug: '2.0.0-rc1',
       }],
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('passes the toolchain arguments each build system needs', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sticky-target-list-test-'));
+  try {
+    writeIntegration(root, {
+      id: 'pio-project',
+      name: 'PlatformIO Project',
+      catalogSection: 'community',
+      build: {
+        system: 'platformio',
+        environment: 'sticky',
+        projectPath: 'source',
+      },
+      flash: {
+        versions: [{ version: '1.0.0', sourceBuild: true }],
+      },
+    });
+    writeIntegration(root, {
+      id: 'arduino-project',
+      name: 'Arduino Project',
+      catalogSection: 'community',
+      build: {
+        system: 'arduino',
+        profile: 'sticky',
+        projectPath: 'source',
+      },
+      flash: {
+        versions: [{ version: '1.0.0', sourceBuild: true }],
+      },
+    });
+
+    const result = spawnSync(process.execPath, [LIST_SCRIPT], {
+      encoding: 'utf8',
+      env: { ...process.env, REGISTRY_ROOT: root },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), {
+      include: [
+        {
+          id: 'arduino-project',
+          name: 'Arduino Project',
+          system: 'arduino',
+          path: 'firmwares/arduino-project/source',
+          profile: 'sticky',
+          version: '1.0.0',
+          versionSlug: '1.0.0',
+        },
+        {
+          id: 'pio-project',
+          name: 'PlatformIO Project',
+          system: 'platformio',
+          path: 'firmwares/pio-project/source',
+          environment: 'sticky',
+          version: '1.0.0',
+          versionSlug: '1.0.0',
+        },
+      ],
     });
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/scripts/package-arduino.mjs
+++ b/scripts/package-arduino.mjs
@@ -3,7 +3,7 @@
 import { join } from 'node:path';
 
 import {
-  readFlasherArgsJson,
+  readArduinoFlashArgs,
   resolveTarget,
   writeFirmwarePackage,
 } from './firmware-package.mjs';
@@ -11,8 +11,8 @@ import {
 const integrationId = process.argv[2];
 const versionLabel = process.argv[3];
 
-const { integration, projectDir, outputDir } = resolveTarget('esp-idf', integrationId, versionLabel);
-const { files, flashSize } = readFlasherArgsJson(join(projectDir, 'build'));
+const { integration, projectDir, outputDir } = resolveTarget('arduino', integrationId, versionLabel);
+const { files, flashSize } = readArduinoFlashArgs(join(projectDir, 'build'));
 const parts = writeFirmwarePackage({
   integration,
   versionLabel,

--- a/scripts/package-arduino.test.mjs
+++ b/scripts/package-arduino.test.mjs
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_SCRIPT = join(SCRIPT_DIR, 'package-arduino.mjs');
+
+function createSketchProject(root, flashSettingsLine) {
+  const integrationDir = join(root, 'firmwares', 'sketch-firmware');
+  const buildDir = join(integrationDir, 'source', 'build');
+  mkdirSync(buildDir, { recursive: true });
+  writeFileSync(
+    join(integrationDir, 'firmware.json'),
+    `${JSON.stringify({
+      id: 'sketch-firmware',
+      name: 'Sketch Firmware',
+      build: {
+        system: 'arduino',
+        profile: 'sticky',
+        projectPath: 'source',
+      },
+      flash: {
+        versions: [{
+          version: '1.0.0',
+          manifestPath: 'firmware/1.0.0/manifest.json',
+        }],
+      },
+    }, null, 2)}\n`,
+  );
+
+  const files = {
+    'blink.ino.bootloader.bin': Buffer.from([0xe9, 0x01]),
+    'blink.ino.partitions.bin': Buffer.from([0xaa, 0x50, 0x02]),
+    'boot_app0.bin': Buffer.from([0x00, 0x00, 0x00, 0x03]),
+    'blink.ino.bin': Buffer.from([0xe9, 0x04, 0x05, 0x06, 0x07]),
+  };
+  for (const [fileName, content] of Object.entries(files)) {
+    writeFileSync(join(buildDir, fileName), content);
+  }
+
+  writeFileSync(
+    join(buildDir, 'flash_args'),
+    [
+      flashSettingsLine,
+      '0x0 blink.ino.bootloader.bin',
+      '0x8000 blink.ino.partitions.bin',
+      '0xe000 boot_app0.bin',
+      '0x10000 blink.ino.bin',
+      '',
+    ].join('\n'),
+  );
+
+  return { integrationDir, files };
+}
+
+function runPackage(root) {
+  const result = spawnSync(
+    process.execPath,
+    [PACKAGE_SCRIPT, 'sketch-firmware', '1.0.0'],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, REGISTRY_ROOT: root },
+    },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  return result;
+}
+
+test('packages the flash map that the arduino-esp32 core reports', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sticky-arduino-package-test-'));
+  try {
+    const { integrationDir, files } = createSketchProject(
+      root,
+      '--flash-mode dio --flash-freq 80m --flash-size 16MB',
+    );
+
+    runPackage(root);
+
+    const manifest = JSON.parse(readFileSync(
+      join(integrationDir, 'firmware', '1.0.0', 'manifest.json'),
+      'utf8',
+    ));
+    assert.equal(manifest.integrationId, 'sketch-firmware');
+    assert.equal(manifest.flashSize, '16MB');
+    assert.equal(manifest.builds[0].chipFamily, 'ESP32-S3');
+    assert.deepEqual(
+      manifest.builds[0].parts.map((part) => [part.path, part.offset, part.size]),
+      [
+        ['blink.ino.bootloader.bin', 0, 2],
+        ['blink.ino.partitions.bin', 32768, 3],
+        ['boot_app0.bin', 57344, 4],
+        ['blink.ino.bin', 65536, 5],
+      ],
+    );
+    assert.equal(
+      manifest.builds[0].parts[3].sha256,
+      createHash('sha256').update(files['blink.ino.bin']).digest('hex'),
+    );
+    assert.deepEqual(
+      readFileSync(join(integrationDir, 'firmware', '1.0.0', 'boot_app0.bin')),
+      files['boot_app0.bin'],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('reads the flash size from cores that still use underscored esptool flags', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sticky-arduino-package-test-'));
+  try {
+    const { integrationDir } = createSketchProject(
+      root,
+      '--flash_mode dio --flash_freq 80m --flash_size 8MB',
+    );
+
+    runPackage(root);
+
+    const manifest = JSON.parse(readFileSync(
+      join(integrationDir, 'firmware', '1.0.0', 'manifest.json'),
+      'utf8',
+    ));
+    assert.equal(manifest.flashSize, '8MB');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/package-platformio.mjs
+++ b/scripts/package-platformio.mjs
@@ -11,8 +11,9 @@ import {
 const integrationId = process.argv[2];
 const versionLabel = process.argv[3];
 
-const { integration, projectDir, outputDir } = resolveTarget('esp-idf', integrationId, versionLabel);
-const { files, flashSize } = readFlasherArgsJson(join(projectDir, 'build'));
+const { integration, projectDir, outputDir } = resolveTarget('platformio', integrationId, versionLabel);
+const buildDir = join(projectDir, '.pio', 'build', integration.build.environment);
+const { files, flashSize } = readFlasherArgsJson(buildDir);
 const parts = writeFirmwarePackage({
   integration,
   versionLabel,

--- a/scripts/package-platformio.test.mjs
+++ b/scripts/package-platformio.test.mjs
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_SCRIPT = join(SCRIPT_DIR, 'package-platformio.mjs');
+
+test('packages the flash map that the PlatformIO build dumps', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sticky-platformio-package-test-'));
+  try {
+    const integrationDir = join(root, 'firmwares', 'pio-firmware');
+    const buildDir = join(integrationDir, 'source', '.pio', 'build', 'sticky');
+    const outputDir = join(root, '.firmware-output', 'pio-firmware', '1.2.0');
+    mkdirSync(buildDir, { recursive: true });
+    writeFileSync(
+      join(integrationDir, 'firmware.json'),
+      `${JSON.stringify({
+        id: 'pio-firmware',
+        name: 'PlatformIO Firmware',
+        build: {
+          system: 'platformio',
+          environment: 'sticky',
+          projectPath: 'source',
+        },
+        flash: {
+          versions: [{
+            version: '1.2.0',
+            sourceBuild: true,
+          }],
+        },
+      }, null, 2)}\n`,
+    );
+
+    const bootloader = Buffer.from([0xe9, 0x01, 0x02]);
+    const partitions = Buffer.from([0xaa, 0x50]);
+    const application = Buffer.from([0xe9, 0x03, 0x04, 0x05]);
+    writeFileSync(join(buildDir, 'bootloader.bin'), bootloader);
+    writeFileSync(join(buildDir, 'partitions.bin'), partitions);
+    writeFileSync(join(buildDir, 'firmware.bin'), application);
+    writeFileSync(
+      join(buildDir, 'flasher_args.json'),
+      `${JSON.stringify({
+        flash_files: {
+          '0x0': 'bootloader.bin',
+          '0x8000': 'partitions.bin',
+          '0x10000': 'firmware.bin',
+        },
+        flash_settings: {
+          flash_size: '16MB',
+        },
+      }, null, 2)}\n`,
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [PACKAGE_SCRIPT, 'pio-firmware', '1.2.0'],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          REGISTRY_ROOT: root,
+          FIRMWARE_OUTPUT_DIR: outputDir,
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+
+    const manifest = JSON.parse(readFileSync(join(outputDir, 'manifest.json'), 'utf8'));
+    assert.equal(manifest.integrationId, 'pio-firmware');
+    assert.equal(manifest.version, '1.2.0');
+    assert.equal(manifest.flashSize, '16MB');
+    assert.deepEqual(
+      manifest.builds[0].parts.map((part) => [part.path, part.offset, part.size]),
+      [
+        ['bootloader.bin', 0, bootloader.length],
+        ['partitions.bin', 32768, partitions.length],
+        ['firmware.bin', 65536, application.length],
+      ],
+    );
+    assert.equal(
+      manifest.builds[0].parts[2].sha256,
+      createHash('sha256').update(application).digest('hex'),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('refuses to package a firmware that declares a different build system', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sticky-platformio-package-test-'));
+  try {
+    const integrationDir = join(root, 'firmwares', 'idf-firmware');
+    mkdirSync(integrationDir, { recursive: true });
+    writeFileSync(
+      join(integrationDir, 'firmware.json'),
+      `${JSON.stringify({
+        id: 'idf-firmware',
+        name: 'IDF Firmware',
+        build: {
+          system: 'esp-idf',
+          version: 'v5.4',
+          target: 'esp32s3',
+          projectPath: 'source',
+        },
+        flash: {
+          versions: [{ version: '1.0.0', manifestPath: 'firmware/1.0.0/manifest.json' }],
+        },
+      }, null, 2)}\n`,
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [PACKAGE_SCRIPT, 'idf-firmware', '1.0.0'],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, REGISTRY_ROOT: root },
+      },
+    );
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /is not configured as a platformio firmware/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/pio-dump-flash-args.py
+++ b/scripts/pio-dump-flash-args.py
@@ -1,0 +1,52 @@
+"""Records the flash layout of a PlatformIO build for the Registry packaging step.
+
+Writes ``$BUILD_DIR/flasher_args.json`` with every flash offset and the file that
+belongs at it, using the same shape ESP-IDF produces. Paths are stored relative to
+the build directory so files that live inside framework packages stay reachable.
+
+把 PlatformIO 本次编译的烧录布局写入 ``$BUILD_DIR/flasher_args.json``,
+格式与 ESP-IDF 生成的同名文件一致。路径以构建目录为基准保存,
+因此位于框架包内的文件同样可以定位。
+
+Usage / 用法::
+
+    PLATFORMIO_EXTRA_SCRIPTS=post:/path/to/pio-dump-flash-args.py pio run -e <env>
+"""
+
+import json
+import os
+
+Import("env")  # noqa: F821
+
+board = env.BoardConfig()  # noqa: F821
+build_dir = env.subst("$BUILD_DIR")  # noqa: F821
+
+images = [
+    (offset, env.subst(path))  # noqa: F821
+    for offset, path in env.get("FLASH_EXTRA_IMAGES", [])  # noqa: F821
+]
+images.append((
+    env.subst("$ESP32_APP_OFFSET"),  # noqa: F821
+    env.subst(os.path.join("$BUILD_DIR", "${PROGNAME}.bin")),  # noqa: F821
+))
+
+flash_files = {}
+for offset, path in images:
+    relative_path = os.path.relpath(path, build_dir).replace(os.sep, "/")
+    flash_files[str(offset)] = relative_path
+
+os.makedirs(build_dir, exist_ok=True)
+with open(os.path.join(build_dir, "flasher_args.json"), "w", encoding="utf8") as handle:
+    json.dump(
+        {
+            "flash_files": flash_files,
+            "flash_settings": {
+                "flash_size": board.get("upload.flash_size", "4MB"),
+            },
+        },
+        handle,
+        indent=2,
+    )
+    handle.write("\n")
+
+print("Recorded %d flash file(s) in %s/flasher_args.json" % (len(flash_files), build_dir))

--- a/scripts/pio-dump-flash-args.test.mjs
+++ b/scripts/pio-dump-flash-args.test.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const DUMP_SCRIPT = join(SCRIPT_DIR, 'pio-dump-flash-args.py');
+
+// Runs the dump script with a stand-in for the SCons environment PlatformIO injects.
+// 用一个替身对象模拟 PlatformIO 注入的 SCons 环境,以此运行导出脚本。
+const HARNESS = `
+import os
+import sys
+
+BUILD_DIR, FRAMEWORK_DIR, SCRIPT_PATH = sys.argv[1:4]
+
+
+class Board:
+    def get(self, key, default=None):
+        return {"upload.flash_size": "16MB"}.get(key, default)
+
+
+class Env:
+    def get(self, key, default=None):
+        if key == "FLASH_EXTRA_IMAGES":
+            return [
+                ("0x0", os.path.join("$BUILD_DIR", "bootloader.bin")),
+                ("0x8000", os.path.join("$BUILD_DIR", "partitions.bin")),
+                ("0xe000", os.path.join(FRAMEWORK_DIR, "boot_app0.bin")),
+            ]
+        return default
+
+    def subst(self, value):
+        return (value
+                .replace("$BUILD_DIR", BUILD_DIR)
+                .replace("\${PROGNAME}", "firmware")
+                .replace("$ESP32_APP_OFFSET", "0x10000"))
+
+    def BoardConfig(self):
+        return Board()
+
+
+with open(SCRIPT_PATH, encoding="utf8") as handle:
+    source = handle.read()
+
+exec(compile(source, SCRIPT_PATH, "exec"), {"Import": lambda name: None, "env": Env()})
+`;
+
+test('records every flash offset PlatformIO reports, including framework files', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sticky-pio-dump-test-'));
+  try {
+    const buildDir = join(root, 'project', '.pio', 'build', 'sticky');
+    const frameworkDir = join(root, 'packages', 'framework-arduinoespressif32', 'tools', 'partitions');
+    mkdirSync(buildDir, { recursive: true });
+    mkdirSync(frameworkDir, { recursive: true });
+    const harnessPath = join(root, 'harness.py');
+    writeFileSync(harnessPath, HARNESS);
+
+    const result = spawnSync(
+      'python3',
+      [harnessPath, buildDir, frameworkDir, DUMP_SCRIPT],
+      { encoding: 'utf8' },
+    );
+    assert.equal(result.status, 0, result.stderr);
+
+    const flasherArgs = JSON.parse(readFileSync(join(buildDir, 'flasher_args.json'), 'utf8'));
+    assert.equal(flasherArgs.flash_settings.flash_size, '16MB');
+    assert.deepEqual(flasherArgs.flash_files, {
+      '0x0': 'bootloader.bin',
+      '0x8000': 'partitions.bin',
+      '0xe000': '../../../../packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin',
+      '0x10000': 'firmware.bin',
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -29,7 +29,14 @@ const ALLOWED_STATUSES = new Set(['experimental', 'beta', 'stable']);
 const ALLOWED_CATALOG_SECTIONS = new Set(['official', 'platform', 'community', 'draft']);
 const ALLOWED_FIRMWARE_CATEGORIES = new Set(['ereader', 'productivity', 'personal', 'weather', 'finance', 'tools', 'fun', 'smart-home', 'other']);
 const ALLOWED_PRINTABLE_CATEGORIES = new Set(['case', 'stand', 'mount', 'accessory', 'reference', 'other']);
-const ALLOWED_BUILD_SYSTEMS = new Set(['esp-idf']);
+// Fields and project marker file each supported build system expects.
+// 每种受支持的编译系统所需的字段,以及用于识别工程的标识文件。
+const BUILD_SYSTEMS = new Map([
+  ['esp-idf', { fields: ['system', 'version', 'target', 'projectPath'], marker: 'CMakeLists.txt' }],
+  ['platformio', { fields: ['system', 'environment', 'projectPath'], marker: 'platformio.ini' }],
+  ['arduino', { fields: ['system', 'profile', 'projectPath'], marker: 'sketch.yaml' }],
+]);
+const BUILD_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const ALLOWED_ASSET_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.svg']);
 const ALLOWED_PHOTO_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp']);
 const PRINTABLE_FIELDS = new Set([
@@ -205,23 +212,37 @@ function validateLocalDirectoryPath(value, integrationDir, scope) {
   return resolvedPath;
 }
 
+// Validates a build block against the field set of its declared build system.
+// 按声明的编译系统,校验 build 段落所要求的字段。
 function validateBuild(value, integrationDir, source, scope) {
-  const allowedKeys = new Set(['system', 'version', 'target', 'projectPath']);
-  if (!validateObjectKeys(value, ['system', 'version', 'target', 'projectPath'], allowedKeys, scope)) {
+  if (!isObject(value)) {
+    addError(scope, 'must be an object');
     return;
   }
-  validateEnum(value.system, ALLOWED_BUILD_SYSTEMS, `${scope}.system`);
-  validateString(value.version, `${scope}.version`, {
-    max: 64,
-    pattern: /^[A-Za-z0-9][A-Za-z0-9._-]*$/,
-  });
-  validateString(value.target, `${scope}.target`, { max: 40, pattern: ID_PATTERN });
+  if (!validateEnum(value.system, new Set(BUILD_SYSTEMS.keys()), `${scope}.system`)) {
+    return;
+  }
+
+  const { fields, marker } = BUILD_SYSTEMS.get(value.system);
+  if (!validateObjectKeys(value, fields, new Set(fields), scope)) {
+    return;
+  }
+
+  if (value.system === 'esp-idf') {
+    validateString(value.version, `${scope}.version`, { max: 64, pattern: BUILD_NAME_PATTERN });
+    validateString(value.target, `${scope}.target`, { max: 40, pattern: ID_PATTERN });
+  } else if (value.system === 'platformio') {
+    validateString(value.environment, `${scope}.environment`, { max: 64, pattern: BUILD_NAME_PATTERN });
+  } else {
+    validateString(value.profile, `${scope}.profile`, { max: 64, pattern: BUILD_NAME_PATTERN });
+  }
+
   const projectPath = validateLocalDirectoryPath(value.projectPath, integrationDir, `${scope}.projectPath`);
   if (source?.path && value.projectPath !== source.path) {
     addError(`${scope}.projectPath`, 'must match source.path');
   }
-  if (projectPath && !existsSync(join(projectPath, 'CMakeLists.txt'))) {
-    addError(`${scope}.projectPath`, 'must contain CMakeLists.txt for an ESP-IDF project');
+  if (projectPath && !existsSync(join(projectPath, marker))) {
+    addError(`${scope}.projectPath`, `must contain ${marker} for the ${value.system} build system`);
   }
 }
 

--- a/scripts/validate-registry.test.mjs
+++ b/scripts/validate-registry.test.mjs
@@ -377,6 +377,118 @@ test('rejects an unsafe ESP-IDF Docker tag', () => {
   assert.match(result.stderr, /build\.version: has an invalid format/);
 });
 
+// Writes an external entry whose only interesting part is its build block.
+// 写入一个只为验证 build 段落而存在的 external 条目。
+function writeBuildIntegration(root, id, build, markerFile) {
+  const integration = validBase(id, 'external');
+  integration.source.path = 'source';
+  integration.build = build;
+  integration.external = {
+    label: 'Open official tool',
+    url: 'https://example.com/tool',
+    description: 'Continue in the maintained upstream tool.',
+  };
+  const integrationDir = writeIntegration(root, integration);
+  mkdirSync(join(integrationDir, 'source'), { recursive: true });
+  if (markerFile) {
+    writeFileSync(join(integrationDir, 'source', markerFile), 'example\n');
+  }
+  return integrationDir;
+}
+
+test('accepts a PlatformIO build block', () => {
+  const root = createRegistry();
+  writeBuildIntegration(
+    root,
+    'pio-firmware',
+    { system: 'platformio', environment: 'sticky', projectPath: 'source' },
+    'platformio.ini',
+  );
+
+  const result = runValidator(root);
+
+  assert.equal(result.status, 0);
+});
+
+test('accepts an Arduino build block', () => {
+  const root = createRegistry();
+  writeBuildIntegration(
+    root,
+    'arduino-firmware',
+    { system: 'arduino', profile: 'sticky', projectPath: 'source' },
+    'sketch.yaml',
+  );
+
+  const result = runValidator(root);
+
+  assert.equal(result.status, 0);
+});
+
+test('rejects an unknown build system', () => {
+  const root = createRegistry();
+  writeBuildIntegration(
+    root,
+    'makefile-firmware',
+    { system: 'makefile', projectPath: 'source' },
+    'Makefile',
+  );
+
+  const result = runValidator(root);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /build\.system: must be one of: esp-idf, platformio, arduino/);
+});
+
+test('rejects a build block that borrows fields from another build system', () => {
+  const root = createRegistry();
+  writeBuildIntegration(
+    root,
+    'pio-with-idf-fields',
+    {
+      system: 'platformio',
+      environment: 'sticky',
+      target: 'esp32s3',
+      projectPath: 'source',
+    },
+    'platformio.ini',
+  );
+
+  const result = runValidator(root);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /build: contains unsupported field "target"/);
+});
+
+test('rejects a PlatformIO project without platformio.ini', () => {
+  const root = createRegistry();
+  writeBuildIntegration(
+    root,
+    'pio-without-ini',
+    { system: 'platformio', environment: 'sticky', projectPath: 'source' },
+    'CMakeLists.txt',
+  );
+
+  const result = runValidator(root);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /build\.projectPath: must contain platformio\.ini/);
+});
+
+test('rejects an Arduino sketch without a profile name', () => {
+  const root = createRegistry();
+  writeBuildIntegration(
+    root,
+    'arduino-without-profile',
+    { system: 'arduino', projectPath: 'source' },
+    'sketch.yaml',
+  );
+
+  const result = runValidator(root);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /build: missing required field "profile"/);
+});
+
 test('accepts a valid template integration with local fragments', () => {
   const root = createRegistry();
   const integration = validBase('template-platform', 'template');

--- a/scripts/verify-build-channel.mjs
+++ b/scripts/verify-build-channel.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const REPOSITORY_ROOT = resolve(import.meta.dirname, '..');
+const VERSION = '0.0.0';
+const ENTRY_ID = 'channel-starter';
+
+// How each build channel compiles its starter project and what CI must install for it.
+// 每条编译通道如何编译自己的示例工程,以及 CI 需要为它准备什么。
+const CHANNELS = new Map([
+  ['platformio', {
+    starter: 'platformio-starter',
+    // PlatformIO takes the project directory as an argument, so any name works.
+    // PlatformIO 通过参数接收工程目录,目录名可以任意。
+    projectDirName: 'source',
+    build: { system: 'platformio', environment: 'sticky' },
+    compile: (projectDir) => ({
+      command: 'pio',
+      args: ['run', '-d', projectDir, '-e', 'sticky'],
+      env: {
+        PLATFORMIO_EXTRA_SCRIPTS: `post:${join(REPOSITORY_ROOT, 'scripts', 'pio-dump-flash-args.py')}`,
+      },
+    }),
+  }],
+  ['arduino', {
+    starter: 'arduino-starter',
+    // Arduino CLI requires the sketch directory and the .ino file to share a name.
+    // Arduino CLI 要求 sketch 目录名与 .ino 文件名相同。
+    projectDirName: 'arduino-starter',
+    build: { system: 'arduino', profile: 'sticky' },
+    compile: (projectDir) => ({
+      command: 'arduino-cli',
+      args: ['compile', '--profile', 'sticky', '--build-path', join(projectDir, 'build'), projectDir],
+      env: {},
+    }),
+  }],
+]);
+
+const systemName = process.argv[2];
+const channel = CHANNELS.get(systemName);
+if (!channel) {
+  throw new Error(`Usage: node scripts/verify-build-channel.mjs <${[...CHANNELS.keys()].join('|')}>`);
+}
+
+// Copies the starter project into a throwaway Registry entry the packaging script accepts.
+// 把示例工程复制成一个临时的 Registry 条目,供打包脚本处理。
+function createRegistryEntry() {
+  const registryRoot = mkdtempSync(join(tmpdir(), `sticky-channel-${systemName}-`));
+  const entryDir = join(registryRoot, 'firmwares', ENTRY_ID);
+  const projectDir = join(entryDir, channel.projectDirName);
+  mkdirSync(entryDir, { recursive: true });
+  cpSync(join(REPOSITORY_ROOT, 'examples', channel.starter), projectDir, { recursive: true });
+  writeFileSync(
+    join(entryDir, 'firmware.json'),
+    `${JSON.stringify({
+      id: ENTRY_ID,
+      name: 'Build channel starter',
+      build: { ...channel.build, projectPath: channel.projectDirName },
+      flash: { versions: [{ version: VERSION, sourceBuild: true }] },
+    }, null, 2)}\n`,
+  );
+  return { registryRoot, projectDir, outputDir: join(registryRoot, 'output') };
+}
+
+function run(command, args, env) {
+  console.log(`$ ${command} ${args.join(' ')}`);
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    env: { ...process.env, ...env },
+  });
+  if (result.error) {
+    throw new Error(`Cannot run ${command}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(`${command} exited with status ${result.status}`);
+  }
+}
+
+// Checks that every manifest part points at a real file with the recorded size and hash.
+// 检查 manifest 中每个片段都对应一个真实文件,且大小与哈希都吻合。
+function assertPackagedFiles(outputDir) {
+  const manifest = JSON.parse(readFileSync(join(outputDir, 'manifest.json'), 'utf8'));
+  const parts = manifest.builds?.[0]?.parts ?? [];
+  if (parts.length < 2) {
+    throw new Error(`Expected at least a bootloader and an application part, got ${parts.length}`);
+  }
+
+  let previousOffset = -1;
+  for (const part of parts) {
+    const content = readFileSync(join(outputDir, part.path));
+    if (content.length !== part.size) {
+      throw new Error(`${part.path} is ${content.length} bytes but the manifest records ${part.size}`);
+    }
+    const sha256 = createHash('sha256').update(content).digest('hex');
+    if (sha256 !== part.sha256) {
+      throw new Error(`${part.path} does not match the sha256 recorded in the manifest`);
+    }
+    if (part.offset <= previousOffset) {
+      throw new Error(`${part.path} is not ordered after offset ${previousOffset}`);
+    }
+    previousOffset = part.offset;
+  }
+
+  return { manifest, parts };
+}
+
+const { registryRoot, projectDir, outputDir } = createRegistryEntry();
+const { command, args, env } = channel.compile(projectDir);
+run(command, args, env);
+run(process.execPath, [
+  join(REPOSITORY_ROOT, 'scripts', `package-${systemName}.mjs`),
+  ENTRY_ID,
+  VERSION,
+], {
+  REGISTRY_ROOT: registryRoot,
+  FIRMWARE_OUTPUT_DIR: outputDir,
+});
+
+const { manifest, parts } = assertPackagedFiles(outputDir);
+console.log(`\nThe ${systemName} channel produced a ${manifest.flashSize ?? 'unknown'} flash layout:`);
+for (const part of parts) {
+  console.log(`  0x${part.offset.toString(16).padStart(6, '0')}  ${String(part.size).padStart(9)} bytes  ${part.path}`);
+}


### PR DESCRIPTION
## What this adds

CI could only build ESP-IDF projects, so 14 of the 15 firmware entries ship
contributor-compiled binaries. This adds PlatformIO and Arduino CLI as build
channels, which covers the toolchains most makers already use.

## How the flash layout is determined

Neither channel assumes fixed flash offsets, because the bootloader address is
board-specific (`0x0` on ESP32-S3, `0x1000` on the classic ESP32). Each one reads
what its toolchain reports:

- **Arduino** — the `flash_args` file the arduino-esp32 core writes next to its
  build artifacts, which lists every offset and file and is self-contained.
- **PlatformIO** — `scripts/pio-dump-flash-args.py`, injected as a post script,
  records `FLASH_EXTRA_IMAGES` and `ESP32_APP_OFFSET` into an ESP-IDF-shaped
  `flasher_args.json`. Paths are stored relative to the build directory so files
  inside framework packages stay reachable.

## Declaring a build system

```json
{ "system": "esp-idf",    "version": "v5.4", "target": "esp32s3", "projectPath": "source" }
{ "system": "platformio", "environment": "sticky",                "projectPath": "source" }
{ "system": "arduino",    "profile": "sticky",                    "projectPath": "my-sketch" }
```

Each system accepts only its own fields. Arduino CLI requires the sketch
directory and the `.ino` file to share a name, so Arduino projects name
`projectPath` after the sketch.

## Keeping the channels verifiable

`examples/platformio-starter/` and `examples/arduino-starter/` are minimal
projects that CI compiles and packages on every change to the build pipeline, via
`scripts/verify-build-channel.mjs`. The check asserts every manifest part points
at a real file with the recorded size, SHA-256, and offset order.

## Verified locally

Both channels were run end to end against real toolchains (PlatformIO Core 6.1.19,
arduino-cli 1.4.1):

| Channel | Offsets produced | Application size |
| --- | --- | --- |
| PlatformIO | `0x0`, `0x8000`, `0xe000`, `0x10000` | 263 856 bytes |
| Arduino | `0x0`, `0x8000`, `0xe000`, `0x10000` | 273 424 bytes |

`npm test` passes with 67 tests, and `npm run validate` passes on all 15 firmware
and 5 printable entries.

## Also in this PR

The build-output rules in `.gitignore` still pointed at `integrations/`, so they
matched nothing after the directory was renamed to `firmwares/`. They now cover
`firmwares/*/*/` plus the PlatformIO and Arduino artifacts.