### PR TITLE
fix: move CrossPlay to Community Firmwares

### DIFF
--- a/firmwares/crossplay/firmware.json
+++ b/firmwares/crossplay/firmware.json
@@ -2,8 +2,9 @@
   "schemaVersion": 1,
   "id": "crossplay",
   "name": "CrossPlay",
-  "group": "partner",
-  "catalogSection": "platform",
+  "group": "community",
+  "catalogSection": "community",
+  "category": "fun",
   "mode": "flash",
   "status": "beta",
   "summary": "Games, puzzles and flashcards for e-ink, on top of a full CrossPoint e-reader.",
@@ -39,7 +40,7 @@
     "games",
     "ereader",
     "flashcards",
-    "partner"
+    "community"
   ],
   "flash": {
     "versions": [


### PR DESCRIPTION
## Contribution type

- [ ] Firmware: new community firmware
- [ ] Firmware: new partner firmware coordinated with the platform owner
- [ ] Firmware: official Sticky firmware update maintained by Seeed
- [x] Firmware: update to an existing firmware
- [ ] 3D printable design: new design or update

## Common verification

- [x] `npm test` passes locally (68 tests).
- [x] `npm run validate` passes locally (16 firmwares, 5 printables).
- [x] The directory name and the `id` in the metadata file are the same lowercase kebab-case identifier.
- [ ] All links use HTTPS and open the intended page.
- [x] The submitted files contain no user-specific credentials, API keys, tokens, passwords, or private keys.

Existing HTTPS links are retained; live link availability was not rechecked for this metadata update.

## Firmware

- Firmware name: CrossPlay
- Directory: `firmwares/crossplay/`
- Firmware version: 1.12.11
- Upstream project: https://github.com/ma-r-s/crossplay
- Source license: MIT, as recorded in the existing package metadata.
- Firmware artifact origin: https://github.com/ma-r-s/crossplay/releases/download/v1.12.11/crossplay-v1.12.11-sticky-full.bin
- SHA-256: `c07efd799ee3d520ff5ff7e407b3401f5e2dfd271fc226d3e248c93f848b21cc`

### Package type

- [ ] Source contribution built by GitHub Actions
- [x] Firmware-only package

### What this firmware provides

Move the existing CrossPlay card into Community Firmwares and classify it under `fun`. Set `group` and `catalogSection` to `community`, add `category: "fun"`, and update the matching tag. CrossPlay provides games, puzzles, and flashcards alongside its e-reader.

### Firmware verification

- [x] `firmware.json` uses the `group`, `catalogSection`, `mode`, and `category` documented in [docs/contributing-firmware.md](https://github.com/Seeed-Projects/reterminal-sticky-playground-registry/blob/main/docs/contributing-firmware.md) for the selected type.
- [x] The README identifies the package origin, firmware version, and tested hardware.
- [ ] Community entries include author attribution and a real Sticky preview; partner entries use the official logo as identity artwork.

Author attribution is present. The existing CrossPlay lockup preview from #45 is retained for this catalog update.

Firmware-only package:

- [x] `source.url` points to the maintained upstream project and `source.license` names its license.
- [x] Every required `.bin` file is committed under `firmware/<version>/`.
- [x] The local manifest records every firmware file, flash offset, byte size, and SHA-256.

Update to an existing firmware:

- [x] The newest version appears first in `flash.versions`.
- [x] Every older version still referenced by `firmware.json` remains available.
- [ ] Existing metadata and assets were updated only where the new version changes them.

This update changes catalog placement for the existing version 1.12.11.

### Physical-device test

The following is the existing maintainer test record in `firmwares/crossplay/README.md`; this metadata update was verified with repository checks and was not flashed again.

- Device and hardware revision: reTerminal Sticky production hardware, as recorded by the maintainer.
- Installation method: published firmware flashed by the project maintainer; tooling was not specified.
- Tested firmware version: 1.12.11 in the existing record.
- Main workflow tested: firmware run and driven with physical buttons, as recorded by the maintainer.
- Reboot and saved-state result: restart recorded for 1.12.11; saved state was not separately rechecked at this version.
- USB reconnection and repeated-install result: not separately rechecked at 1.12.11.

- [ ] The submitted firmware-only package or a local build of the submitted source was installed on a physical reTerminal Sticky.
- [ ] First boot and the main user workflow passed.
- [ ] Touch and hardware buttons used by the firmware passed.
- [ ] Reboot, saved state, USB reconnection, and repeated installation were tested where applicable.

## Additional context

The change is limited to `firmwares/crossplay/firmware.json`. The existing binary, manifest, version, and artwork are retained. Documentation already describes the current package and installation workflow, so no documentation edits are needed. `git diff --check` passes.
