### PR TITLE
feat: allow 5 MB preview photos in registry CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,7 +222,7 @@ These are enforced by `npm run validate` and by review.
 | One directory per contribution | Everything for one firmware or one design lives in its own directory. Do not touch other directories in the same PR. |
 | Directory name = `id` | Lowercase letters, digits, and single hyphens only: `^[a-z0-9]+(?:-[a-z0-9]+)*$`, 2–64 characters. Examples: `sticky-2048`, `wallet-case`. The `id` field inside the metadata file must be identical. |
 | HTTPS links only | Every URL field must start with `https://`. |
-| Images under `assets/` | Referenced as `assets/<file>`. Firmware accepts PNG, JPG, WebP, or static SVG; printables accept PNG, JPG, WebP. Maximum 1 MB for previews and logos; 1200–1600 px on the long edge is plenty. |
+| Images under `assets/` | Referenced as `assets/<file>`. Firmware accepts PNG, JPG, WebP, or static SVG; printables accept PNG, JPG, WebP. Maximum 5 MB for previews, 1 MB for logos. |
 | Real images | Previews are real screenshots or photos on a reTerminal Sticky. Renders and stock images are not accepted. |
 | English card text | `name`, `summary`, `description`, `alt` texts, and README are in English because the website serves a global audience. |
 | No secrets | Source, configuration, and README contain no Wi-Fi passwords, API keys, tokens, or private keys. Use placeholders and describe runtime setup instead. |

--- a/docs/contributing-firmware.md
+++ b/docs/contributing-firmware.md
@@ -279,7 +279,7 @@ Community firmware categories:
 |---|---|---|---|---|
 | `compatibility.devices` | array | Yes | exactly `["reterminal-sticky"]` | Always `["reterminal-sticky"]` |
 | `compatibility.notes` | string | No | up to 400 chars | Tested hardware revision, required accessories, known limits |
-| `assets.preview` | string | Yes | `assets/<file>.(png\|jpg\|jpeg\|webp\|svg)`, ≤ 1 MB | Real Sticky screenshot or photo of the firmware running |
+| `assets.preview` | string | Yes | `assets/<file>.(png\|jpg\|jpeg\|webp\|svg)`, ≤ 5 MB | Real Sticky screenshot or photo of the firmware running |
 | `assets.previewAlt` | string | Yes | 1–180 chars | One sentence describing the preview |
 | `assets.logo` | string | No | same pattern, ≤ 1 MB | Optional project logo. Partner entries use their official logo here and in `preview` |
 

--- a/docs/contributing-firmware.zh-CN.md
+++ b/docs/contributing-firmware.zh-CN.md
@@ -274,7 +274,7 @@ cp -R firmwares/_template firmwares/my-firmware
 |---|---|---|---|---|
 | `compatibility.devices` | 数组 | 是 | 必须恰好是 `["reterminal-sticky"]` | 固定写 `["reterminal-sticky"]` |
 | `compatibility.notes` | 字符串 | 否 | 最长 400 字符 | 测试过的硬件版本、需要的配件、已知限制 |
-| `assets.preview` | 字符串 | 是 | `assets/<文件>.(png\|jpg\|jpeg\|webp\|svg)`，≤ 1 MB | 固件运行中的真实 Sticky 截图或照片 |
+| `assets.preview` | 字符串 | 是 | `assets/<文件>.(png\|jpg\|jpeg\|webp\|svg)`，≤ 5 MB | 固件运行中的真实 Sticky 截图或照片 |
 | `assets.previewAlt` | 字符串 | 是 | 1–180 字符 | 一句话描述预览图 |
 | `assets.logo` | 字符串 | 否 | 同上格式，≤ 1 MB | 可选的项目标识。合作伙伴条目在这里和 `preview` 都使用官方 logo |
 

--- a/docs/contributing-printables.md
+++ b/docs/contributing-printables.md
@@ -134,7 +134,7 @@ optional; **any other key makes validation fail**. The formal definition is
 
 | Field | Type | Required | Limits | What to write |
 |---|---|---|---|---|
-| `preview.image` | string | Yes | must match `^assets/[A-Za-z0-9._-]+\.(png\|jpg\|jpeg\|webp)$`; file ≤ 1 MB | Path to the photo inside your directory, normally `assets/preview.jpg` |
+| `preview.image` | string | Yes | must match `^assets/[A-Za-z0-9._-]+\.(png\|jpg\|jpeg\|webp)$`; file ≤ 5 MB | Path to the photo inside your directory, normally `assets/preview.jpg` |
 | `preview.alt` | string | Yes | 1–180 chars | One sentence describing the photo for screen readers and image search, for example `Black PETG wallet case fitted on reTerminal Sticky, front view` |
 
 ### Complete example
@@ -198,7 +198,7 @@ before opening your page.
 | Real photo | The printed part fitted on a real reTerminal Sticky. Renders, slicer screenshots, and photos without the device are not accepted. |
 | Framing | Landscape, roughly 4:3. The card crops to that ratio, so keep the subject centred. |
 | Format | JPG, PNG, or WebP. JPG is usually smallest. |
-| Size | Up to 1 MB. 1200–1600 px on the long edge is plenty. |
+| Size | Up to 5 MB. 1200–1600 px on the long edge is plenty. |
 | Path | Inside `assets/`, referenced exactly in `preview.image`. |
 | Content | No watermarks, no text overlays, no other products. |
 
@@ -376,7 +376,7 @@ for `printables/my-case/printable.json`:
 | `...printable.json.preview.image: references a missing file: assets/preview.jpg` | File name or extension differs, or the file was not added to git | Check spelling and case; run `git add printables/my-case/assets` |
 | `...printable.json.preview.image: must use one of these file extensions: .png, .jpg, .jpeg, .webp` | HEIC, SVG, GIF, or other format | Export as JPG or PNG |
 | `...printable.json.preview.image: does not contain a valid JPEG file signature` | A PNG (or other file) renamed to `.jpg` | Re-export in the right format, or rename to the real extension and update `preview.image` |
-| `...printable.json.preview.image: must not exceed 1 MB` | Photo too large | Resize to about 1600 px on the long edge |
+| `...printable.json.preview.image: must not exceed 5 MB` | Photo too large | Resize to about 1600 px on the long edge |
 | `...printable.json.tags: must be an array containing no more than 6 tags` | Too many tags | Keep the six most useful |
 | `...printable.json.tags[2]: duplicates tag "case"` | Same tag twice | Remove the duplicate |
 | `...printable.json.README.md: references a missing file: README.md` | README deleted or not committed | Add `printables/my-case/README.md` |
@@ -442,7 +442,7 @@ directories under `printables/` for more real examples.
 - [ ] `summary` is one sentence (≤ 140 characters); `description`, if given, is two or three sentences (≤ 800).
 - [ ] `author.name` credits the designer; `author.url` (if given) is HTTPS.
 - [ ] `download.url` is the public HTTPS page; `download.platform` (if given) is the hosting site's name; `download.license` matches the page when a license is shown.
-- [ ] `assets/preview.jpg` is a real photo of the print on reTerminal Sticky, ≤ 1 MB, referenced exactly in `preview.image`, with a descriptive `preview.alt`.
+- [ ] `assets/preview.jpg` is a real photo of the print on reTerminal Sticky, ≤ 5 MB, referenced exactly in `preview.image`, with a descriptive `preview.alt`.
 - [ ] `README.md` lists print settings, assembly steps, hardware, files link, and license.
 - [ ] No model files are committed.
 - [ ] `npm test` and `npm run validate` pass.

--- a/docs/contributing-printables.zh-CN.md
+++ b/docs/contributing-printables.zh-CN.md
@@ -128,7 +128,7 @@ printables/
 
 | 字段 | 类型 | 必填 | 限制 | 填什么 |
 |---|---|---|---|---|
-| `preview.image` | 字符串 | 是 | 必须匹配 `^assets/[A-Za-z0-9._-]+\.(png\|jpg\|jpeg\|webp)$`；文件 ≤ 1 MB | 照片在目录内的路径，通常是 `assets/preview.jpg` |
+| `preview.image` | 字符串 | 是 | 必须匹配 `^assets/[A-Za-z0-9._-]+\.(png\|jpg\|jpeg\|webp)$`；文件 ≤ 5 MB | 照片在目录内的路径，通常是 `assets/preview.jpg` |
 | `preview.alt` | 字符串 | 是 | 1–180 字符 | 一句话描述照片内容，供读屏软件和图片搜索使用，例如 `Black PETG wallet case fitted on reTerminal Sticky, front view` |
 
 ### 完整示例
@@ -189,7 +189,7 @@ printables/
 | 真实照片 | 打印成品装在真机 reTerminal Sticky 上。渲染图、切片软件截图、没有设备的照片都不接受。 |
 | 构图 | 横向，约 4:3。卡片会按这个比例裁切，主体放在中间。 |
 | 格式 | JPG、PNG 或 WebP。JPG 通常最小。 |
-| 大小 | 最大 1 MB。长边 1200–1600 px 足够。 |
+| 大小 | 最大 5 MB。长边 1200–1600 px 足够。 |
 | 路径 | 放在 `assets/` 下，与 `preview.image` 完全一致。 |
 | 内容 | 不加水印、不叠文字、不出现其他产品。 |
 
@@ -354,7 +354,7 @@ Sticky 网站发布上线，见
 | `...printable.json.preview.image: references a missing file: assets/preview.jpg` | 文件名或后缀不一致，或没加进 git | 检查拼写和大小写；执行 `git add printables/my-case/assets` |
 | `...printable.json.preview.image: must use one of these file extensions: .png, .jpg, .jpeg, .webp` | HEIC、SVG、GIF 等格式 | 导出为 JPG 或 PNG |
 | `...printable.json.preview.image: does not contain a valid JPEG file signature` | 把 PNG（或别的文件）直接改名成 `.jpg` | 用正确格式重新导出，或改回真实后缀并更新 `preview.image` |
-| `...printable.json.preview.image: must not exceed 1 MB` | 照片过大 | 缩到长边约 1600 px |
+| `...printable.json.preview.image: must not exceed 5 MB` | 照片过大 | 缩到长边约 1600 px |
 | `...printable.json.tags: must be an array containing no more than 6 tags` | 标签太多 | 保留最有用的 6 个 |
 | `...printable.json.tags[2]: duplicates tag "case"` | 同一标签出现两次 | 删掉重复项 |
 | `...printable.json.README.md: references a missing file: README.md` | README 被删或没提交 | 加上 `printables/my-case/README.md` |
@@ -417,7 +417,7 @@ Dropthetenors 的 Sticky Wallet Case 发布在 Thingiverse。它在本仓库里�
 - [ ] `summary` 是一句话（≤ 140 字符）；填了 `description` 的话是两三句话（≤ 800）。
 - [ ] `author.name` 写明设计者；`author.url`（如有）是 HTTPS。
 - [ ] `download.url` 是公开 HTTPS 页面；填了 `download.platform` 的话是托管网站名；下载页标注了许可证时 `download.license` 与之一致。
-- [ ] `assets/preview.jpg` 是打印成品装在 reTerminal Sticky 上的真实照片，≤ 1 MB，与 `preview.image` 完全一致，并有描述性的 `preview.alt`。
+- [ ] `assets/preview.jpg` 是打印成品装在 reTerminal Sticky 上的真实照片，≤ 5 MB，与 `preview.image` 完全一致，并有描述性的 `preview.alt`。
 - [ ] `README.md` 写明打印参数、组装步骤、五金件、文件链接和许可证。
 - [ ] 没有提交任何模型文件。
 - [ ] `npm test` 和 `npm run validate` 通过。

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -468,7 +468,7 @@ function validateAssets(value, integrationDir, scope) {
   }
   const previewPath = validateLocalFilePath(value.preview, integrationDir, `${scope}.preview`, {
     extensions: ALLOWED_ASSET_EXTENSIONS,
-    maxBytes: 1024 * 1024,
+    maxBytes: 5 * 1024 * 1024,
   });
   validateAssetContent(previewPath, `${scope}.preview`);
   validateString(value.previewAlt, `${scope}.previewAlt`, { max: 180 });
@@ -984,7 +984,7 @@ function validatePrintable(printableDir, directoryName, seenIds) {
     }
     const imagePath = validateLocalFilePath(printable.preview.image, printableDir, `${previewScope}.image`, {
       extensions: ALLOWED_PHOTO_EXTENSIONS,
-      maxBytes: 1024 * 1024,
+      maxBytes: 5 * 1024 * 1024,
     });
     validateAssetContent(imagePath, `${previewScope}.image`);
     validateString(printable.preview.alt, `${previewScope}.alt`, { max: 180 });

--- a/scripts/validate-registry.test.mjs
+++ b/scripts/validate-registry.test.mjs
@@ -900,6 +900,70 @@ test('rejects a printable design whose download page is not HTTPS', () => {
   assert.match(result.stderr, /download\.url: must use HTTPS/);
 });
 
+function jpegOfSize(bytes) {
+  const buffer = Buffer.alloc(bytes, 0);
+  buffer[0] = 0xff;
+  buffer[1] = 0xd8;
+  buffer[2] = 0xff;
+  return buffer;
+}
+
+function webpOfSize(bytes) {
+  const buffer = Buffer.alloc(bytes, 0);
+  buffer.write('RIFF', 0, 'ascii');
+  buffer.writeUInt32LE(bytes - 8, 4);
+  buffer.write('WEBP', 8, 'ascii');
+  return buffer;
+}
+
+test('accepts preview photos larger than 1 MB and at most 5 MB', () => {
+  const printableRoot = createRegistry();
+  const printable = validPrintable('large-photo-stand');
+  const printableDir = writePrintable(printableRoot, printable);
+  writeFileSync(join(printableDir, 'assets', 'preview.jpg'), jpegOfSize((1024 * 1024) + 1));
+
+  const printableResult = runValidator(printableRoot);
+  assert.equal(printableResult.status, 0, printableResult.stderr);
+
+  const firmwareRoot = createRegistry();
+  const firmware = validBase('large-preview-app', 'external');
+  firmware.external = {
+    label: 'Open official tool',
+    url: 'https://example.com/tool',
+    description: 'Continue in the maintained upstream tool.',
+  };
+  const firmwareDir = writeIntegration(firmwareRoot, firmware);
+  writeFileSync(join(firmwareDir, 'assets', 'preview.webp'), webpOfSize((1024 * 1024) + 1));
+
+  const firmwareResult = runValidator(firmwareRoot);
+  assert.equal(firmwareResult.status, 0, firmwareResult.stderr);
+});
+
+test('rejects preview photos larger than 5 MB', () => {
+  const printableRoot = createRegistry();
+  const printable = validPrintable('huge-photo-stand');
+  const printableDir = writePrintable(printableRoot, printable);
+  writeFileSync(join(printableDir, 'assets', 'preview.jpg'), jpegOfSize((5 * 1024 * 1024) + 1));
+
+  const printableResult = runValidator(printableRoot);
+  assert.equal(printableResult.status, 1);
+  assert.match(printableResult.stderr, /preview\.image: must not exceed 5 MB/);
+
+  const firmwareRoot = createRegistry();
+  const firmware = validBase('huge-preview-app', 'external');
+  firmware.external = {
+    label: 'Open official tool',
+    url: 'https://example.com/tool',
+    description: 'Continue in the maintained upstream tool.',
+  };
+  const firmwareDir = writeIntegration(firmwareRoot, firmware);
+  writeFileSync(join(firmwareDir, 'assets', 'preview.webp'), webpOfSize((5 * 1024 * 1024) + 1));
+
+  const firmwareResult = runValidator(firmwareRoot);
+  assert.equal(firmwareResult.status, 1);
+  assert.match(firmwareResult.stderr, /assets\.preview: must not exceed 5 MB/);
+});
+
 test('rejects a printable design whose preview photo is missing', () => {
   const root = createRegistry();
   const printable = validPrintable('no-photo-stand');


### PR DESCRIPTION
## Summary
- Registry CI now accepts firmware and printable preview photos up to 5 MB, matching the Playground submission form.
- Logo files stay at 1 MB.
- Contributing docs and validator tests use the same 5 MB preview limit.

## Test plan
- [x] `node --test scripts/validate-registry.test.mjs` (42 passing, including new 1 MB+ accept and 5 MB+ reject cases)
- [ ] Open a form PR whose preview is between 1 MB and 5 MB and confirm Validate Registry is green
- [ ] Confirm a preview larger than 5 MB still fails with `must not exceed 5 MB`